### PR TITLE
🔧 api: Update Dockerfile command to start application

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -87,4 +87,4 @@ COPY --from=prod-deps /app/node_modules ./node_modules
 EXPOSE 3000
 
 # Démarrer l'application
-CMD ["sh", "-c", "pnpm db:migrate:up --config=dist/config/mikro-orm.config.js && pnpm start"]
+CMD ["sh", "-c", "pnpm db:migrate:up --config=dist/config/mikro-orm.config.js && node dist/main.js"]


### PR DESCRIPTION
Replaced the command in the Dockerfile to start the application using 'node dist/main.js' instead of 'pnpm start' after running database migrations. This change ensures a more direct execution of the main application file.