### PR TITLE
Fix path to openapi docs

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -61,8 +61,8 @@ async function bootstrap() {
 
   addSchemasToSwagger(document)
 
-  SwaggerModule.setup('docs', app, document, {
-    jsonDocumentUrl: '/docs-json',
+  SwaggerModule.setup(`${PREFIX}/docs`, app, document, {
+    jsonDocumentUrl: `${PREFIX}/docs-json`,
     customSiteTitle: 'Lonestone API Documentation',
     customfavIcon: '/favicon.ico',
     customJs: [

--- a/packages/openapi-generator/openapi-ts.config.ts
+++ b/packages/openapi-generator/openapi-ts.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@hey-api/openapi-ts'
 
 export default defineConfig({
   input:
-    `${process.env.API_URL}/docs-json`,
+    `${process.env.API_URL}/api/docs-json`,
   output: {
     format: 'prettier',
     lint: 'eslint',


### PR DESCRIPTION
as per https://github.com/nestjs/swagger/issues/105 SwaggerModule does not comply with setGlobalPrefix fix: included '/api' in the path to docs and docs-json, subsequently pointed the generator to /api/docs-json