### PR TITLE
🐛 upgrade node version to use 24.10.0 LTS. This supports ESM import i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "keywords": [],
   "engines": {
-    "node": "22.14.0",
+    "node": "24.10.0",
     "pnpm": "10.5.0"
   },
   "scripts": {


### PR DESCRIPTION
…n CJS

fixes 64