### PR TITLE
fix(deps): pin better-auth to an exact version in the catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   auth:
     better-auth:
-      specifier: ^1.4.18
+      specifier: 1.4.18
       version: 1.4.18
   build:
     '@types/node':
@@ -4149,6 +4149,7 @@ packages:
 
   '@types/glob@9.0.0':
     resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
+    deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -9608,6 +9609,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,9 +34,15 @@ catalogs:
     react-i18next: ^16.5.4
     i18next: ^25.8.0
   auth:
-    # Better Auth
-    better-auth: ^1.4.18
-    "@better-auth/expo": ^1.4.6
+    # Better Auth — pinned to an EXACT version on purpose. Better Auth has
+    # shipped behaviour-breaking changes in minor releases (e.g. 1.6 validates
+    # sign-in additionalFields from the request body before the user.create
+    # hooks run, where 1.4 validated them after). A floating range here means a
+    # deploy that does not use `pnpm install --frozen-lockfile` can silently pull
+    # a newer minor than the lockfile and break auth in prod only. Bump
+    # deliberately and test the auth flows when you do.
+    better-auth: 1.4.18
+    "@better-auth/expo": 1.4.6
   build:
     # Node, vite, ts
     "@types/node": ^25.1.0


### PR DESCRIPTION
## Context

A downstream project (Raconte) hit a **production-only** auth outage: email OTP sign-up returned "invalid code" and no account was ever created, while sign-in for existing users worked. It could not be reproduced locally.

**Root cause: silent version drift.** `better-auth` was a floating `^1.4.x` range. The prod build did **not** use `pnpm install --frozen-lockfile`, so it resolved **1.6.x** while local/lockfile stayed on **1.4.x**. In 1.6.x the `sign-in/email-otp` endpoint validates user `additionalFields` from the request body **before** the `user.create` database hooks run (1.4.x validated them *after*). A required field injected by a `before` hook therefore threw before the hook could populate it, and the user was never created. Invisible locally because local was on 1.4.x.

The boilerplate itself is not directly affected (no OTP / required `additionalFields` / user-create hook), and its Dockerfiles already use `--frozen-lockfile`. But the floating range is the same risk class for any consumer that deploys without a frozen install or adds those auth patterns.

## Change

Pin `better-auth` (and `@better-auth/expo`) to an **exact** version in the `auth` catalog, so the resolved version is deterministic no matter how a consumer installs. Lockfile synced (resolves the same 1.4.18, no drift).

## Recommendation for consumers

- Always deploy with `pnpm install --frozen-lockfile` (the Dockerfiles here already do; check PaaS/custom deploys).
- Treat better-auth minor bumps as potentially breaking: bump deliberately and smoke-test the auth flows (sign-up, sign-in, org, sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)