### PR TITLE
ci(boilerstone): fail the Release PR until unreleased intentions are promoted

### DIFF
--- a/.boilerstone/docs/release-maintainer-runbook.md
+++ b/.boilerstone/docs/release-maintainer-runbook.md
@@ -76,8 +76,9 @@ git diff --name-status vPREVIOUS..HEAD
 ```
 
 5. Confirm the release note exists (`apps/documentation/src/content/docs/releases/vX.Y.Z.mdx`). It may already be on `main` from an earlier PR — that is the intended path, not a shortcut. If it is missing, write it here. See [Drafting the release note](#drafting-the-release-note-before-or-on-the-release-pr).
-6. Update `.boilerstone/boilerplate.example.json` so `source.currentVersion` is `X.Y.Z`. Only maintainers edit this example file, and only at release time.
-7. Validate:
+6. Confirm staged intentions were promoted. The **Intention promote** check fails until every `unreleased/*.md` that was on `main` has moved to `vX.Y.Z/NN-slug.md` with `id: vX.Y.Z/slug`. If it fails, the error is the command to run. A release that had nothing in `unreleased/` passes. GitHub has no yellow “needs work” check that also blocks merge, so this one fails like the other gates.
+7. Update `.boilerstone/boilerplate.example.json` so `source.currentVersion` is `X.Y.Z`. Only maintainers edit this example file, and only at release time.
+8. Validate:
 
 ```bash
 pnpm boilerplate intentions sync
@@ -92,8 +93,8 @@ pnpm test
 
 If this release changed CLI command behavior, flags, safety rules, or the meaning of a term used in the docs, update the matching `.boilerstone/docs/` pages in the same PR. The changelog line is not enough.
 
-8. Smoke test as a consumer (see below).
-9. Stop. Hand the Release PR back. **Never tag. Never merge.** The human merges from the GitHub UI as themselves. After merge, release-please creates `vX.Y.Z`.
+9. Smoke test as a consumer (see below).
+10. Stop. Hand the Release PR back. **Never tag. Never merge.** The human merges from the GitHub UI as themselves. After merge, release-please creates `vX.Y.Z`.
 
 ## Smoke test as a consumer
 

--- a/.claude/skills/boilerstone-release/SKILL.md
+++ b/.claude/skills/boilerstone-release/SKILL.md
@@ -25,6 +25,7 @@ git tag --list 'v*' --sort=-v:refname                          # previous versio
 pnpm boilerplate intentions promote --to X.Y.Z                 # unreleased/ → vX.Y.Z/NN-slug.md, ids rewritten
 git diff --name-status vPREVIOUS..HEAD                         # staleness-check intentions against the diff
 # draft apps/documentation/src/content/docs/releases/vX.Y.Z.mdx
+# Intention promote CI fails until unreleased/ has been promoted (error is the command)
 pnpm boilerplate intentions sync                                # regenerate the release README intentions block
 pnpm boilerplate intentions lint                                # validate published intention metadata
 pnpm boilerplate upgrade path --from <prev> --to <next> --json  # dry-run the resulting path

--- a/.cursor/skills/boilerstone-release/SKILL.md
+++ b/.cursor/skills/boilerstone-release/SKILL.md
@@ -25,6 +25,7 @@ git tag --list 'v*' --sort=-v:refname                          # previous versio
 pnpm boilerplate intentions promote --to X.Y.Z                 # unreleased/ → vX.Y.Z/NN-slug.md, ids rewritten
 git diff --name-status vPREVIOUS..HEAD                         # staleness-check intentions against the diff
 # draft apps/documentation/src/content/docs/releases/vX.Y.Z.mdx
+# Intention promote CI fails until unreleased/ has been promoted (error is the command)
 pnpm boilerplate intentions sync                                # regenerate the release README intentions block
 pnpm boilerplate intentions lint                                # validate published intention metadata
 pnpm boilerplate upgrade path --from <prev> --to <next> --json  # dry-run the resulting path

--- a/.github/workflows/intention-promote.yml
+++ b/.github/workflows/intention-promote.yml
@@ -1,0 +1,134 @@
+name: Intention promote
+
+# On a Release PR, staged unreleased/*.md files must have moved into
+# vX.Y.Z/NN-slug.md with rewritten ids. GitHub has no in-between check
+# conclusion that both nags and blocks merge (skip is silent, fail is
+# red, "neutral" does not block). This job fails with a command in the
+# error, like the other gates. Non-Release PRs skip.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  intention-promote:
+    name: Intention promote
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect a Release PR
+        id: gate
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if [[ ",${LABELS}," == *",autorelease: pending,"* ]]; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=false" >> "$GITHUB_OUTPUT"
+            echo "Not a Release PR (no autorelease: pending label). Skipping."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.required == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require unreleased intentions to be promoted
+        if: steps.gate.outputs.required == 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${BASE_REF}"
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          skip = {"README.md", "TEMPLATE.md", "classification.md"}
+          base_ref = f"origin/{os.environ['BASE_REF']}"
+          prefix = ".boilerstone/migration-intentions"
+
+          def git_ls(ref: str, folder: str) -> list[str]:
+              result = subprocess.run(
+                  ["git", "ls-tree", "-r", "--name-only", ref, folder],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              names = []
+              for line in result.stdout.splitlines():
+                  name = Path(line).name
+                  if name.endswith(".md") and name not in skip:
+                      names.append(name)
+              return sorted(names)
+
+          if not Path(".release-please-manifest.json").is_file():
+              print("Could not read .release-please-manifest.json on the PR HEAD.")
+              sys.exit(1)
+
+          version = json.load(open(".release-please-manifest.json"))["."]
+          dest_dir = Path(prefix) / f"v{version}"
+          staged_folder = f"{prefix}/unreleased"
+
+          leftover = git_ls("HEAD", staged_folder)
+          on_base = git_ls(base_ref, staged_folder)
+
+          if leftover:
+              print("Staged intentions are still in unreleased/. Promote them before merging:")
+              print(f"  pnpm boilerplate intentions promote --to {version}")
+              print("Still staged:")
+              for name in leftover:
+                  print(f"  - unreleased/{name}")
+              sys.exit(1)
+
+          if not on_base:
+              print("Nothing to promote: unreleased/ had no intention files on the base branch.")
+              sys.exit(0)
+
+          missing = []
+          wrong_id = []
+          for name in on_base:
+              slug = name[: -len(".md")]
+              matches = []
+              if dest_dir.is_dir():
+                  matches = [
+                      path
+                      for path in dest_dir.iterdir()
+                      if re.fullmatch(rf"\d+-{re.escape(slug)}\.md", path.name)
+                  ]
+              if not matches:
+                  missing.append(slug)
+                  continue
+              text = matches[0].read_text(encoding="utf-8")
+              if not re.search(
+                  rf"^id:\s*v{re.escape(version)}/{re.escape(slug)}\s*$",
+                  text,
+                  re.M,
+              ):
+                  wrong_id.append(f"{matches[0].name} (expected id: v{version}/{slug})")
+
+          if missing or wrong_id:
+              print(f"unreleased/ is empty, but the files did not land in {dest_dir}/.")
+              print("Promote (do not delete) with:")
+              print(f"  pnpm boilerplate intentions promote --to {version}")
+              print("  pnpm boilerplate intentions sync")
+              if missing:
+                  print("Missing:")
+                  for slug in missing:
+                      print(f"  - v{version}/NN-{slug}.md")
+              if wrong_id:
+                  print("Wrong id:")
+                  for item in wrong_id:
+                      print(f"  - {item}")
+              sys.exit(1)
+
+          print(f"Promoted {len(on_base)} intention(s) to v{version}/.")
+          PY

--- a/scripts/github-repo-settings.md
+++ b/scripts/github-repo-settings.md
@@ -44,6 +44,7 @@ Require pull requests, and require these status checks to pass:
 
 - [ ] `PR title and description` (workflow: **PR lint**)
 - [ ] `Intention gate` (workflow: **Intention gate**) — boilerplate producer; skips successfully when `no-intention` or `autorelease: pending` is present
+- [ ] `Intention promote` (workflow: **Intention promote**) — boilerplate producer; skips on ordinary PRs. On a Release PR it fails until staged `unreleased/` files have moved into `vX.Y.Z/`
 - [ ] `Release note` (workflow: **Release note**) — other PRs skip this check successfully
 - [ ] Existing CI jobs (`Lint`, `Type Check`, `Build`, `Test`, …)
 


### PR DESCRIPTION
The intention gate skips on Release PRs, so a merge could ship with files still sitting in unreleased/. GitHub has no yellow check that also blocks merge, so this job fails with the promote command in the error. It compares against main rather than testing for an empty folder, so deleting a file is not the same as promoting it.

Made with [Cursor](https://cursor.com)