### PR TITLE
fix(ci): rebase the Release PR on every push to main

### DIFF
--- a/.boilerstone/docs/release-maintainer-runbook.md
+++ b/.boilerstone/docs/release-maintainer-runbook.md
@@ -59,6 +59,8 @@ A few sentences on why this release exists and what the bundle means for consume
 
 The version number is already chosen. `CHANGELOG.md` is already generated. Do not pick a version by hand. Do not edit the changelog. Do not tag. Do not merge — that is the human's final act; release-please creates the tag after merge.
 
+release-please **force-pushes** this branch on every push to `main` (`always-update` in `release-please-config.json`). Extra commits you add here — promoted intentions, the example version bump — disappear if `main` moves afterwards. Do this work when the bundle is ready to ship, then merge before the next push to `main`. If the branch was rewritten, re-run promote.
+
 1. Check out the Release PR (`autorelease: pending`). Read the next version from `.release-please-manifest.json`.
 2. Review the generated `CHANGELOG.md`. It is the inventory. Do not stamp or rename it.
 3. Promote staged intentions:

--- a/.boilerstone/migration-intentions/unreleased/adopt-release-please.md
+++ b/.boilerstone/migration-intentions/unreleased/adopt-release-please.md
@@ -36,7 +36,7 @@ Do not turn this on while the project still ships without versions. Do not force
 Work through each gap independently; skip any that is already closed. Skip this whole intention when the project stays without versions.
 
 1. **release-please config and workflow** — signal: no `release-please-config.json`, no `.release-please-manifest.json`, or no `.github/workflows/release-please.yml`.
-   Adapt the staged reference `release-please-config.json` (`include-component-in-tag` must stay `false` so tags are `vX.Y.Z`). Adapt `.release-please-manifest.json` so `"."` is this project's current version, not a guessed bump. Adapt `.github/workflows/release-please.yml` for the default branch if it is not `main`. Do not merge the Release PR with `GITHUB_TOKEN` — that merge never starts the follow-up run that creates the tag.
+   Adapt the staged reference `release-please-config.json` (`include-component-in-tag` must stay `false` so tags are `vX.Y.Z`; keep `always-update` true so the Release PR rebases when hidden commit types land on the default branch; keep `pull-request-title-pattern` as `chore(ci): release ${version}` so the title passes commitlint). Adapt `.release-please-manifest.json` so `"."` is this project's current version, not a guessed bump. Adapt `.github/workflows/release-please.yml` for the default branch if it is not `main`. Do not merge the Release PR with `GITHUB_TOKEN` — that merge never starts the follow-up run that creates the tag.
    Done when: the three files exist, the manifest version matches the project today, and the workflow opens or updates a Release PR on push to the default branch.
 
 2. **Generated changelog** — signal: `CHANGELOG.md` is missing, or it is still a hand-edited Keep-a-Changelog file with an `[Unreleased]` section the team maintains by hand.
@@ -79,7 +79,7 @@ Work through each gap independently; skip any that is already closed. Skip this 
 
 ## Validation
 
-- The three release-please files exist and `include-component-in-tag` is `false`.
+- The three release-please files exist, `include-component-in-tag` is `false`, and `always-update` is `true`.
 - `CHANGELOG.md` still contains the project's older version sections.
 - `.github/workflows/release-note.yml` exists.
 - `.github/workflows/push-to-ghcr.yml` lists a `v*` tag trigger and semver image tags.

--- a/.claude/skills/boilerstone-release/SKILL.md
+++ b/.claude/skills/boilerstone-release/SKILL.md
@@ -39,4 +39,5 @@ Then smoke-test as a consumer (see the runbook) and stop.
 - Never an unbounded "update dependencies" step.
 - Keep Reference Paths small and specific, and label every path `copy` or `adapt`.
 - Do not edit `CHANGELOG.md` by hand. Do not `git tag`. Do not merge.
+- Promote last: release-please force-pushes the Release PR on every push to `main`. If the branch was rewritten after you promoted, re-run promote.
 - Domain / scope values live in `commitlint.config.ts` — do not restate the list.

--- a/.cursor/skills/boilerstone-release/SKILL.md
+++ b/.cursor/skills/boilerstone-release/SKILL.md
@@ -39,4 +39,5 @@ Then smoke-test as a consumer (see the runbook) and stop.
 - Never an unbounded "update dependencies" step.
 - Keep Reference Paths small and specific, and label every path `copy` or `adapt`.
 - Do not edit `CHANGELOG.md` by hand. Do not `git tag`. Do not merge.
+- Promote last: release-please force-pushes the Release PR on every push to `main`. If the branch was rewritten after you promoted, re-run promote.
 - Domain / scope values live in `commitlint.config.ts` — do not restate the list.

--- a/apps/documentation/src/content/docs/explanations/2_contribution-and-release.mdx
+++ b/apps/documentation/src/content/docs/explanations/2_contribution-and-release.mdx
@@ -132,6 +132,14 @@ Commit **scopes** are the project's domains, defined once in `commitlint.config.
 
 We used to forbid generated changelogs. That rule predates agent-written commits: back then, generation meant compiling messy WIP subjects into noise. With curated squash messages, the generated changelog *is* the curated inventory — the granularity is decided by the author (one paragraph per change) and the reasons live in commit bodies, one link away. The two arguments for hand-curation disappeared, so the rule did too.
 
+### Why the Release PR rebases on every push
+
+release-please's default is to update the Release PR only when the generated changelog would change. Hidden types (`ci`, `chore`, `test`, `style`, `build`) never change that changelog, so a CI gate merged to `main` would leave the Release PR on a stale snapshot — new checks would not even run on it.
+
+That default is correct for a PR that is only a generated version bump. Ours is also a working branch (promote intentions, bump the example version). It has to stay on top of `main`. `always-update` is the first-party switch for that: every push rebases the PR. The cost is a force-push, so extra commits on the Release PR are dropped when `main` moves. Promote last; merge before the next push. See the [release maintainer runbook](https://github.com/lonestone/lonestone-boilerplate/blob/main/.boilerstone/docs/release-maintainer-runbook.md#working-the-release-pr).
+
+The same config sets the Release PR title to `chore(ci): release X.Y.Z`. The default title uses the branch name as scope (`chore(main): …`), which is not a domain in `commitlint.config.ts`, so PR lint would block the merge.
+
 ### Why release notes live in the docs app
 
 A changelog line cannot say "these five PRs together deliver X" — that context spans commits and partly lives outside the repo. So each release gets a human-written note in `apps/documentation/src/content/docs/releases/`, and the GitHub Release body is a **mirror** of it, not the other way around. The docs app publishes to GitHub Pages, so release notes double as public product communication. Notes are optional by default and enforced per repository — see [Release and versioning](/lonestone-boilerplate/references/1_release_and_versionning#changelog-and-release-notes).

--- a/apps/documentation/src/content/docs/fr/explanations/2_contribution-and-release.mdx
+++ b/apps/documentation/src/content/docs/fr/explanations/2_contribution-and-release.mdx
@@ -132,6 +132,14 @@ Les **scopes** des commits sont les domaines du projet, définis une seule fois 
 
 Nous interdisions les changelogs générés. Cette règle date d'avant les commits écrits par agents : à l'époque, générer voulait dire compiler des sujets WIP brouillons en bruit. Avec des messages de squash soignés, le changelog généré *est* l'inventaire soigné — la granularité est décidée par l'auteur (un paragraphe par changement) et les raisons vivent dans les corps de commits, à un lien de distance. Les deux arguments pour la curation manuelle ont disparu, la règle aussi.
 
+### Pourquoi la Release PR se rebase à chaque push
+
+Par défaut, release-please ne met à jour la Release PR que si le changelog généré changerait. Les types masqués (`ci`, `chore`, `test`, `style`, `build`) ne changent jamais ce changelog : un check CI mergé sur `main` laisserait donc la Release PR sur un instantané périmé — les nouveaux checks ne s'y exécuteraient même pas.
+
+Ce défaut est correct pour une PR qui n'est qu'un bump de version généré. La nôtre est aussi une branche de travail (promouvoir les intentions, mettre à jour la version d'exemple). Elle doit rester au-dessus de `main`. `always-update` est l'option officielle pour ça : chaque push rebase la PR. Le coût est un force-push, donc les commits extra sur la Release PR disparaissent quand `main` avance. Promouvoir en dernier ; merger avant le push suivant. Voir le [runbook du mainteneur de release](https://github.com/lonestone/lonestone-boilerplate/blob/main/.boilerstone/docs/release-maintainer-runbook.md#working-the-release-pr).
+
+La même config fixe le titre de la Release PR à `chore(ci): release X.Y.Z`. Le titre par défaut utilise le nom de branche comme scope (`chore(main): …`), qui n'est pas un domaine dans `commitlint.config.ts`, donc le lint de PR bloquerait le merge.
+
 ### Pourquoi les notes de release vivent dans l'app de documentation
 
 Une ligne de changelog ne peut pas dire « ces cinq PR ensemble livrent X » — ce contexte traverse les commits et vit en partie hors du dépôt. Chaque release reçoit donc une note humaine dans `apps/documentation/src/content/docs/releases/`, et le corps de la GitHub Release en est un **miroir**, pas l'inverse. L'app de documentation est publiée sur GitHub Pages, donc les notes de release servent aussi de communication produit publique. Les notes sont optionnelles par défaut et imposées par dépôt — voir [Release et versionnement](/lonestone-boilerplate/fr/references/1_release_and_versionning#changelog-et-notes-de-release).

--- a/apps/documentation/src/content/docs/fr/references/1_release_and_versionning.mdx
+++ b/apps/documentation/src/content/docs/fr/references/1_release_and_versionning.mdx
@@ -27,7 +27,7 @@ Un nouveau projet démarre généralement **sans versions** : en début de déve
 
 Les deux modes partagent le même pipeline de build — un mode est de la configuration, pas un chemin de CD différent. La config release-please et son workflow sont déjà livrés avec le template : passer de « sans versions » à « versionné » revient à activer ces fichiers.
 
-En mode versionné, [release-please](https://github.com/googleapis/release-please) maintient une Release PR : elle accumule les changements mergés sur `main`, génère le changelog, et c'est là que la note de release s'écrit. La merger crée le tag `v*` et les images versionnées.
+En mode versionné, [release-please](https://github.com/googleapis/release-please) maintient une Release PR : elle accumule les changements mergés sur `main`, génère le changelog, et c'est là que la note de release s'écrit. La merger crée le tag `v*` et les images versionnées. La PR se rebase sur `main` à chaque push (`always-update`). Cette mise à jour est un force-push : le travail fait sur la Release PR elle-même (intentions promues) doit donc se faire en dernier — voir le [runbook du mainteneur de release](https://github.com/lonestone/lonestone-boilerplate/blob/main/.boilerstone/docs/release-maintainer-runbook.md#working-the-release-pr).
 
 :::caution[Ne jamais auto-merger la Release PR]
 Des checks verts signifient « cette PR a le droit de merger », pas « envoyez ça en production ». Un humain décide quand une release a lieu. Et même alors, merger la Release PR ne fait que publier le tag et les images — déployer est une étape séparée, décrite dans [Promouvoir une version](#promouvoir-une-version).

--- a/apps/documentation/src/content/docs/references/1_release_and_versionning.mdx
+++ b/apps/documentation/src/content/docs/references/1_release_and_versionning.mdx
@@ -27,7 +27,7 @@ New projects usually start **without versions**: during early development, every
 
 Both modes share the same build pipeline — a mode is configuration, not a different CD path. The release-please config and workflow already ship with the template, so moving from "without versions" to "versioned" is just a matter of turning those files on.
 
-In versioned mode, [release-please](https://github.com/googleapis/release-please) maintains a Release PR: it accumulates the changes merged on `main`, generates the changelog, and is where the release note is written. Merging it creates the `v*` tag and the versioned images.
+In versioned mode, [release-please](https://github.com/googleapis/release-please) maintains a Release PR: it accumulates the changes merged on `main`, generates the changelog, and is where the release note is written. Merging it creates the `v*` tag and the versioned images. The PR rebases onto `main` on every push (`always-update`). That update force-pushes, so work done on the Release PR itself (promoted intentions) must happen last — see the [release maintainer runbook](https://github.com/lonestone/lonestone-boilerplate/blob/main/.boilerstone/docs/release-maintainer-runbook.md#working-the-release-pr).
 
 :::caution[Never auto-merge the Release PR]
 Green checks mean "this PR is allowed to merge", not "send this to production". A human decides when a release happens. And even then, merging the Release PR only publishes the tag and the images — deploying is a separate step, described in [Promoting a version](#promoting-a-version).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "node",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
+  "always-update": true,
+  "pull-request-title-pattern": "chore(ci): release ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Added" },
     { "type": "fix", "section": "Fixed" },


### PR DESCRIPTION
release-please skips the update when hidden commit types do not change the changelog, so new CI never ran on the Release PR. always-update is the first-party switch for that rebase. The default title uses the branch as scope, which is not a domain, so pull-request-title-pattern is chore(ci): release ${version}.

This PR updates the existing unreleased adopt-release-please intention rather than adding a new one.


Made with [Cursor](https://cursor.com)