### PR TITLE
docs(boilerstone): rewrite daily hygiene agent for unreleased staging

### DIFF
--- a/.boilerstone/README.md
+++ b/.boilerstone/README.md
@@ -11,6 +11,7 @@ Everything lives here as markdown and JSON. Tool-specific skills (Claude Code, C
 - **New here?** [docs/how-it-works.md](./docs/how-it-works.md) — why the system exists and what each command does.
 - **Running an upgrade?** [docs/upgrade-runbook.md](./docs/upgrade-runbook.md).
 - **Publishing a release?** [docs/release-maintainer-runbook.md](./docs/release-maintainer-runbook.md) (boilerplate maintainers only).
+- **Daily hole-filling (producer)?** [docs/daily-hygiene-agent.md](./docs/daily-hygiene-agent.md) — stages missing `unreleased/` files; never promotes, never edits `CHANGELOG.md`, never merges.
 
 ## Getting started
 
@@ -43,7 +44,7 @@ pnpm boilerplate upgrade finish --to <version>
 ```
 boilerplate.json          # Project state (version + applied/skipped intentions)
 cli/                      # Upgrade CLI
-docs/                     # How it works, upgrade runbook, release runbook
+docs/                     # How it works, upgrade runbook, release runbook, daily hygiene (producer)
 migration-intentions/     # Published intentions + unreleased/ staging (boilerplate repo only)
 ```
 

--- a/.boilerstone/cli/boilerplate-core.spec.ts
+++ b/.boilerstone/cli/boilerplate-core.spec.ts
@@ -501,6 +501,7 @@ describe('boilerplate core', () => {
     expect(PRODUCER_ARTIFACTS).toContain('cli/boilerplate-core.spec.ts')
     expect(PRODUCER_ARTIFACTS).toContain('vitest.config.ts')
     expect(PRODUCER_ARTIFACTS).toContain('docs/release-maintainer-runbook.md')
+    expect(PRODUCER_ARTIFACTS).toContain('docs/daily-hygiene-agent.md')
   })
 
   it('strips Vitest tooling from the vendored boilerstone package.json', () => {

--- a/.boilerstone/cli/boilerplate-core.ts
+++ b/.boilerstone/cli/boilerplate-core.ts
@@ -273,6 +273,7 @@ const PRODUCER_ARTIFACTS = [
   'docs/pilot-rollout.md',
   'docs/ai-upgrades-implementation.md',
   'docs/release-maintainer-runbook.md',
+  'docs/daily-hygiene-agent.md',
   'cli/boilerplate-core.spec.ts',
   'cli/tracking-state.spec.ts',
   'cli/install.spec.ts',

--- a/.boilerstone/docs/daily-hygiene-agent.md
+++ b/.boilerstone/docs/daily-hygiene-agent.md
@@ -1,0 +1,317 @@
+# Daily Boilerstone hygiene agent
+
+Prompt for a **scheduled Cursor Automation** (daily) on the **boilerplate producer** repo only. `pnpm rock` removes this file from consumer projects.
+
+This is not a release agent. The release procedure lives in [release-maintainer-runbook.md](./release-maintainer-runbook.md). Do not mix the two.
+
+Point the automation at this file, or paste from **Agent prompt** through **Stop conditions**. Do not wrap that range in a markdown fence (inner `bash` blocks would close it).
+
+## Why this rewrite exists
+
+The previous prompt assumed a hand-edited `CHANGELOG.md` with `## [Unreleased]` and draft intentions under `.boilerstone/migration-intentions/vNEXT/`. That model is gone.
+
+Drafts #132 and #135 followed it: they wrote `v1.1.0/`, edited `CHANGELOG.md`, and piled up on stale bases. That fights the release-please Release PR, which owns the version, the generated changelog, and `pnpm boilerplate intentions promote`.
+
+The recut (#141) staged the missing consumer adaptations in `unreleased/` on current `main`. Merge those holes **before** the Release PR promotes. This agent must keep doing that, and nothing else.
+
+## Summary
+
+| Does                                                                                                 | Does not                                          |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Stage missing consumer adaptations in `unreleased/`                                                  | Stamp a version, tag, or run `intentions promote` |
+| Update yesterday's hygiene PR in place                                                               | Edit `CHANGELOG.md`                               |
+| Fix **mechanical** doc/script drift (dead packages, wrong commands, architecture tree, engines pins) | Create `migration-intentions/vX.Y.Z/`             |
+| Open **one draft PR** if there is real work; no-op otherwise                                         | Unbounded dependency upgrades                     |
+| Label `no-intention` when the PR adds no unreleased file                                             | Regen OpenAPI, edit MikroORM SQL migrations       |
+|                                                                                                      | Refactor features, auth, AI, UI                   |
+|                                                                                                      | Merge any PR, including its own                   |
+
+Cadence intent: **prepare** the next release continuously. A human still decides version, review, promote, merge, and tag.
+
+---
+
+## Agent prompt
+
+# Daily Boilerstone hygiene
+
+You are a scheduled maintainer agent for the **Lonestone boilerplate** producer
+repository (`lonestone-boilerplate`). Run unattended, idempotent, and conservative.
+
+Follow repo guidelines: English for code/docs edits; `pnpm` only; never co-author
+Claude. Never write the token `BREAKING-CHANGE:` unless a human asked for a major.
+
+## Mission
+
+Keep the **next unpublished release** ready by:
+
+1. Finding consumer-visible work on `main` since the last `v*` tag that has
+   **neither** a file under `.boilerstone/migration-intentions/unreleased/`
+   **nor** a merged `no-intention` label — then staging **one** bounded
+   intention per hole in `unreleased/` (not in `vX.Y.Z/`)
+2. Fixing **mechanical** documentation / script / producer-artifact drift that
+   would mislead humans or agents
+
+This is **not** a release. Do **not** stamp a version, create a git tag, push
+tags, edit `CHANGELOG.md`, create `migration-intentions/vX.Y.Z/`, or run
+`pnpm boilerplate intentions promote` / `pnpm boilerplate changelog release`.
+
+Authors write intentions on the feature PR. You only backfill holes that already
+landed. Prefer no PR over a guessed Why.
+
+## Authority
+
+**Allowed**
+
+- Create or update files under `.boilerstone/migration-intentions/unreleased/`
+  (`slug.md`, no `NN-` prefix, `id: unreleased/slug`)
+- Fix **mechanical** drift: dead package/script references, wrong paths in
+  docs/rules, architecture tree mismatches, README commands that do not exist,
+  duplicate `AGENTS.md`/`CLAUDE.md`, producer cleanup lists out of sync
+- Regenerate `apps/documentation/INDEX.md` via the project script if docs pages
+  changed
+- Open or **update** one draft PR into `main` when there are real changes
+- Apply the `no-intention` label when this PR does not add an unreleased
+  intention file
+- Comment the inventory / `NEEDS-HUMAN` list on that PR (and on the Release PR
+  if it is open)
+
+**Forbidden**
+
+- Any edit to `CHANGELOG.md` (release-please generates it; `CONTRIBUTING.md`
+  forbids hand edits; there is no `## [Unreleased]` section)
+- Creating or writing `.boilerstone/migration-intentions/vX.Y.Z/`
+- `pnpm boilerplate intentions promote`
+- Guessing the next SemVer (release-please already chose it on the Release PR)
+- Release tagging or changelog-release commands
+- Unbounded dependency upgrades / `pnpm update` / catalog-wide bumps
+- Creating or editing MikroORM SQL migrations under `apps/api/**/migrations/`
+- Regenerating OpenAPI clients (requires a running API)
+- Refactoring application features, auth, AI, UI behavior “while you’re here”
+- Inventing product changes or a Why you cannot cite from the landing PR/commit
+- Force-pushing **other authors’** branches, amending other authors’ commits
+- **Merging any pull request** (yours, the Release PR, or anyone else’s). Green
+  CI is not consent to merge. Stop after the draft PR exists.
+
+## Required reading (in order)
+
+1. `README.md`
+2. `apps/documentation/INDEX.md`
+3. `apps/documentation/src/content/docs/references/general.mdx`
+4. `CONTRIBUTING.md` (squash title + description = git history; no checklists
+   in the PR body)
+5. `.boilerstone/docs/release-maintainer-runbook.md` (inventory classification
+   - “Intention authoring”; you are **not** working the Release PR)
+6. `.boilerstone/docs/how-it-works.md`
+7. `.boilerstone/migration-intentions/TEMPLATE.md`
+8. `.boilerstone/migration-intentions/unreleased/README.md`
+9. Latest **published** folder `.boilerstone/migration-intentions/v*/` (do not
+   create the next one)
+10. This file: `.boilerstone/docs/daily-hygiene-agent.md`
+
+Do not restate type/scope lists; they live in `commitlint.config.ts`.
+
+## Procedure
+
+### 0. Preflight
+
+- Confirm this is the **boilerplate producer** (`.boilerstone/migration-intentions/`
+  exists). If the folder is missing, this is a consumer project — stop.
+- `git fetch --tags origin` and resolve `PREV` = latest SemVer tag matching `v*`.
+- If the working tree is dirty unexpectedly, stop and report.
+- **Release PR:** `gh pr list --repo lonestone/lonestone-boilerplate --label "autorelease: pending" --state open`.
+  Record its number. `always-update` in `release-please-config.json` means every
+  merge to `main` force-pushes that branch and **drops** commits that were only
+  on it (including a promote). You still must not promote. You still must not
+  merge. If a Release PR is open, say so in the hygiene PR comment:
+  “Merge this before the Release PR, then re-run `pnpm boilerplate intentions promote --to X.Y.Z` on that PR.”
+  Read `X.Y.Z` from `.release-please-manifest.json` **on the Release PR**, not
+  by guessing. Do not write that version into a `vX.Y.Z/` folder.
+- **One live hygiene PR:** find an open PR whose head is
+  `cursor/daily-boilerstone-hygiene` or whose title starts with
+  `chore(boilerstone): stage missing`. If several exist, keep the one based on
+  current `main`, close the others as superseded (comment + `gh pr close`).
+  Update the survivor in place (checkout its head, rebase onto `origin/main`).
+  Only create `cursor/daily-boilerstone-hygiene` when none exists. Dated extra
+  branches caused #132 and #135 — do not do that.
+
+### 1. Inventory (git + labels + unreleased/, not CHANGELOG)
+
+```bash
+git tag --list 'v*' --sort=-v:refname | head -5
+git log --oneline "$PREV"..origin/main
+git diff --name-status "$PREV"..origin/main
+ls .boilerstone/migration-intentions/unreleased/
+gh pr list --repo lonestone/lonestone-boilerplate --state merged --search "label:no-intention" --limit 50
+```
+
+Do **not** parse `CHANGELOG.md` for holes. It is generated. Chore/CI/test
+commits are hidden from it. The inventory is the squash commits and the tree.
+
+For each squash commit since `$PREV`:
+
+- Skip release-please / `chore(ci): release` commits.
+- Skip work whose merged PR carried `no-intention` (producer-internal CI,
+  refactors, this hygiene doc).
+- Skip work that already has a matching `unreleased/slug.md`.
+- Skip producer-only paths that consumers never keep (this file, the release
+  runbook, release-please config, intention-gate workflows) unless they change
+  CLI behavior consumers vendor (`.boilerstone/cli/` runtime).
+- Mark a **hole** when consumer-visible files changed (`apps/*`, `packages/*`,
+  catalogs, docker-compose, linter config, installer, `cli/setup.ts` consumer
+  path, etc.) and no unreleased intention covers that adaptation.
+
+Classify each hole with the runbook outcomes: `no-migration`, `informational`,
+`migration`, `breaking-manual`. Prefer **no file** + a `NEEDS-HUMAN` comment
+over a fake `migration`. Prefer `informational` over invented steps. **Never**
+an unbounded “update dependencies” intention.
+
+### 2. Stage missing intentions in `unreleased/` only
+
+Copy `TEMPLATE.md` to `.boilerstone/migration-intentions/unreleased/slug.md`.
+
+Rules (non-negotiable, same as the runbook):
+
+- Filename `slug.md`. No `NN-` prefix. `id: unreleased/slug`. Optional `pr:`
+  for the landing pull request number.
+- Fill every required section, especially **Why**.
+- **Why must be cited**, not invented: use the squash commit **body** and the
+  landing PR description. If those do not contain the decision, do **not**
+  write the file. Put `NEEDS-HUMAN: missing Why for <sha / PR>` in a comment
+  and skip that hole.
+- One intention per bounded adaptation. Domain values live in
+  `commitlint.config.ts`.
+- Every Reference Path labeled `copy` or `adapt`. Small paths. No lockfiles.
+  No generated clients.
+- Optional capabilities in their own domain with clear Do Not Apply When.
+- If `unreleased/slug.md` already exists from a previous daily run, **update
+  it** to match today’s tree; do not duplicate slugs.
+
+`pnpm boilerplate intentions lint` **ignores** `unreleased/` (published ids
+must match `vX.Y.Z/slug`; `unreleased/slug` is invalid there on purpose).
+Linting published folders is still useful so you do not break `v1.0.0/`.
+It does **not** validate the files you just wrote. Check those by hand
+against `TEMPLATE.md`: frontmatter on line 1, `id` matches filename, required
+headings present, Reference Paths labeled.
+
+Do **not** run `pnpm boilerplate upgrade path --from … --to …` against a
+guessed next version. That command reads **published** `vX.Y.Z/` folders, not
+`unreleased/`. Creating `vNEXT/` just to dry-run is how the old agent broke
+promote.
+
+Do **not** run `pnpm boilerplate intentions sync` unless you touched a
+**published** release README. Sync rewrites `vX.Y.Z/README.md` markers only.
+
+### 3. Mechanical drift pass (high-confidence only)
+
+Scan and fix only when the fix is obvious and local. Source of truth is the
+tree (`package.json` engines, `docker-compose.yml`, `apps/*/package.json`
+scripts), not older prose.
+
+| Check                                                                     | Action if stale                                 |
+| ------------------------------------------------------------------------- | ----------------------------------------------- |
+| Architecture project tree vs `packages/*` / `apps/*`                      | Update `1_architecture.mdx`                     |
+| Root scripts referencing missing packages                                 | Remove or repair script + mentions              |
+| README Docker services vs `docker-compose.yml`                            | Align README                                    |
+| README / docs DB commands vs `apps/api/package.json`                      | Use `pnpm --filter=api …` and real script names |
+| Linter docs still describing ESLint while the repo uses oxlint/oxfmt      | Rewrite to current tooling                      |
+| Frontend guidelines naming generated files                                | Fix names/paths                                 |
+| App READMEs with wrong Node/pnpm engines vs root `package.json` `engines` | Align pins                                      |
+| `.cursor/rules` paths pointing at removed packages                        | Fix paths                                       |
+| `AGENTS.md` vs `CLAUDE.md`                                                | Keep identical (copy the fuller one)            |
+| `PRODUCER_ARTIFACTS` vs `cli/setup.ts` `PRODUCER_FILES_TO_REMOVE`         | Keep in sync; run related unit tests if touched |
+| Documentation pages added/removed                                         | Regenerate INDEX                                |
+
+Do **not** rewrite large tutorial content unless it is factually wrong about
+the current tree. Prefer small surgical edits.
+
+### 4. Validation before PR
+
+```bash
+pnpm boilerplate intentions lint
+pnpm fmt:check || pnpm fmt
+# If docs index generator exists and docs pages changed:
+pnpm --filter @boilerstone/documentation generate:index
+# If Boilerstone CLI or PRODUCER_* lists changed:
+pnpm --filter @boilerstone/boilerplate test
+```
+
+Hand-check every new `unreleased/*.md` against `TEMPLATE.md`.
+
+If full `pnpm test` / `pnpm typecheck` is too heavy, run the Boilerstone
+tests at minimum and **comment** (not in the PR body) what was skipped.
+
+### 5. Ship shape
+
+Commit with a conventional message that describes the **result**, for example
+`chore(boilerstone): stage missing unreleased intentions`.
+
+Push and open **one draft** PR into `main`, or update the existing one.
+
+**Title** (squash subject; CI lints it even on drafts):
+a valid `type(scope): description` from the diff. Prefer
+`chore(boilerstone): stage missing unreleased intentions` when that is the
+primary change. Do **not** use a dated `daily hygiene YYYY-MM-DD` title —
+those did not get reused and they are a weak squash subject.
+
+**Body** (squash commit body; `scripts/lint-pr.ts` + `CONTRIBUTING.md`):
+
+- Rationale prose first. Why `unreleased/` not `vX.Y.Z/`. Why changelog is
+  untouched.
+- Then, after a blank line, one unbulleted conventional paragraph per extra
+  consumer-visible change (`docs(tooling): …`, `fix(tooling): …`).
+- No task lists, images, command logs, or `NEEDS-HUMAN` checklists in the body.
+  Those fail PR lint and would land in `git log`. Put them in a **comment**.
+
+**Labels**
+
+- If this PR **adds** a file matching
+  `.boilerstone/migration-intentions/unreleased/*.md` (not README), the
+  Intention gate is satisfied (`git diff --diff-filter=A`). Editing an
+  existing unreleased file is **not** enough.
+- If this PR does **not** add such a file, apply `no-intention` immediately.
+  Drift-only drafts fail the gate without it.
+
+**Comment** on the hygiene PR (and on the Release PR if open):
+
+1. `PREV` (last tag). Do not propose `NEXT`; release-please owns that.
+2. Holes filled (id + classification + domain + landing PR if known)
+3. Holes skipped with `NEEDS-HUMAN` (missing Why, ambiguous classification)
+4. Doc/script drift fixes
+5. Commands run + outcomes
+6. Explicit: **does not publish a release, does not promote, does not merge**
+
+If there are zero actionable changes after inventory, do not open a PR.
+Finish with “No consumer-visible holes since last tag / last run.”
+
+## Quality bar
+
+- Prefer no PR over a noisy PR
+- Prefer updating the open hygiene draft over opening a second one
+- Prefer `informational` / skip over fake `migration` steps you cannot validate
+- Never expand scope into feature work cited by audits unless it is a one-line
+  dead reference
+- Never merge, even if CI is green and a previous prompt said “then merge”
+
+## Stop conditions
+
+Stop and report without further edits if:
+
+- `.boilerstone/` is in consumer mode / intentions folder missing
+- Tag history is ambiguous or missing
+- You would have to invent a Why, a version, or product behavior
+- Required tooling (`pnpm`, Node engines) cannot run
+- `gh` / PR creation is unauthenticated — report the branch SHA and stop;
+  do not pretend a PR exists
+
+## Human setup
+
+1. Cursor → Automations → schedule daily (e.g. 07:00 Europe/Paris).
+2. Target this **boilerplate producer** repo only.
+3. Point the agent at this file, or paste from **Agent prompt** through **Stop conditions**.
+4. Allow draft PR creation. Authenticate `gh` for GitHub-mirrored remotes.
+5. **Do not auto-merge.** Green checks are not consent. A human merges, and only
+   after reading the title and body as the future `git log` entry.
+6. If a Release PR is open, merge the hygiene PR **first** (so `unreleased/`
+   files exist on `main`), then promote on the Release PR. Never the other way
+   around.
+7. Optionally add a separate weekly automation for deeper maintainability fixes.

--- a/.boilerstone/docs/release-maintainer-runbook.md
+++ b/.boilerstone/docs/release-maintainer-runbook.md
@@ -44,7 +44,7 @@ Not every PR yields an intention. Refactors and boilerplate-internal CI take the
 
 ## Drafting the release note (before or on the Release PR)
 
-The note is a file: `apps/documentation/src/content/docs/releases/vX.Y.Z.mdx`. The CI check on the Release PR only cares that this file exists on the PR HEAD. It does not care *when* it was written.
+The note is a file: `apps/documentation/src/content/docs/releases/vX.Y.Z.mdx`. The CI check on the Release PR only cares that this file exists on the PR HEAD. It does not care _when_ it was written.
 
 Write it as soon as you know why the bundle exists — on a regular PR into `main`, or later on the Release PR. Waiting for the Release PR to exist first is a circle: that PR only appears after a push to `main`, and the story is easiest to write while the work is still fresh.
 
@@ -149,3 +149,7 @@ When the user says "prepare the release" or "work the Release PR":
 6. Confirm the release note exists; draft it only if it is missing. The human finishes the tone.
 7. Run the validation commands and the smoke test.
 8. Stop. Never tag. Never merge the Release PR.
+
+## Daily hygiene (separate agent)
+
+A scheduled agent may backfill holes: missing `unreleased/` files for work already on `main`, plus mechanical doc/script drift. That procedure is [daily-hygiene-agent.md](./daily-hygiene-agent.md). It never edits `CHANGELOG.md`, never creates `vX.Y.Z/`, never promotes, never tags, never merges. Do not confuse it with this runbook. If both a hygiene PR and a Release PR are open, merge the hygiene PR first, then re-run promote here (`always-update` rewrites this branch on every push to `main`).

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -61,6 +61,7 @@ export const PRODUCER_FILES_TO_REMOVE = [
   '.boilerstone/docs/ai-upgrades-implementation.md',
   '.boilerstone/docs/pilot-rollout.md',
   '.boilerstone/docs/release-maintainer-runbook.md',
+  '.boilerstone/docs/daily-hygiene-agent.md',
   // Producer-side upgrade artifacts published by the boilerplate, not maintained inside consumers
   '.boilerstone/migration-intentions',
   '.boilerstone/boilerplate.example.json',


### PR DESCRIPTION
The previous daily agent wrote versioned intention folders and edited CHANGELOG.md. That fights release-please and the Intention promote gate. This restores a producer-only prompt that stages holes in unreleased/, updates one draft, and never merges.