### PR TITLE
fix(tooling): rewrite leftover @boilerstone imports during pnpm rock

### DIFF
--- a/.boilerstone/cli/boilerplate-core.ts
+++ b/.boilerstone/cli/boilerplate-core.ts
@@ -276,6 +276,7 @@ const PRODUCER_ARTIFACTS = [
   'cli/boilerplate-core.spec.ts',
   'cli/tracking-state.spec.ts',
   'cli/install.spec.ts',
+  'cli/setup-rename.spec.ts',
   'cli/vitest.setup.ts',
   'vitest.config.ts',
 ]

--- a/.boilerstone/cli/setup-rename.spec.ts
+++ b/.boilerstone/cli/setup-rename.spec.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { rewriteWorkspaceScope } from '../../cli/setup'
+
+const fixtures: string[] = []
+
+function createFixtureRoot(): string {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rock-scope-'))
+  fixtures.push(rootPath)
+  return rootPath
+}
+
+function writeFile(rootPath: string, relativePath: string, content: string): void {
+  const filePath = join(rootPath, relativePath)
+  mkdirSync(join(filePath, '..'), { recursive: true })
+  writeFileSync(filePath, content, 'utf-8')
+}
+
+function readFile(rootPath: string, relativePath: string): string {
+  return readFileSync(join(rootPath, relativePath), 'utf-8')
+}
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+describe('rewriteWorkspaceScope', () => {
+  it('rewrites leftover @boilerstone/ imports, aliases, and docs', () => {
+    const rootPath = createFixtureRoot()
+    writeFile(
+      rootPath,
+      'apps/web-ssr/app/root.tsx',
+      "import { Button } from '@boilerstone/ui/components/primitives/button'\n",
+    )
+    writeFile(
+      rootPath,
+      'packages/ui/src/lib/utils.ts',
+      "export { cn } from '@boilerstone/ui/lib/utils'\n",
+    )
+    writeFile(
+      rootPath,
+      'packages/ui/tsconfig.json',
+      JSON.stringify({ compilerOptions: { paths: { '@boilerstone/ui/*': ['./src/*'] } } }),
+    )
+    writeFile(
+      rootPath,
+      'packages/ui/components.json',
+      JSON.stringify({ aliases: { utils: '@boilerstone/ui/lib/utils' } }),
+    )
+    writeFile(
+      rootPath,
+      'apps/documentation/src/content/docs/references/frontend.mdx',
+      'Use components from @boilerstone/ui and types from @boilerstone/openapi-generator.\n',
+    )
+    writeFile(
+      rootPath,
+      '.github/workflows/ci.yml',
+      'run: pnpm --filter @boilerstone/i18n check-translations\n',
+    )
+
+    const actualCount = rewriteWorkspaceScope(rootPath, '@boilerstone', '@acme')
+
+    expect(actualCount).toBe(6)
+    expect(readFile(rootPath, 'apps/web-ssr/app/root.tsx')).toContain(
+      '@acme/ui/components/primitives/button',
+    )
+    expect(readFile(rootPath, 'packages/ui/src/lib/utils.ts')).toContain('@acme/ui/lib/utils')
+    expect(readFile(rootPath, 'packages/ui/tsconfig.json')).toContain('@acme/ui/*')
+    expect(readFile(rootPath, 'packages/ui/components.json')).toContain('@acme/ui/lib/utils')
+    expect(readFile(rootPath, 'apps/documentation/src/content/docs/references/frontend.mdx')).toBe(
+      'Use components from @acme/ui and types from @acme/openapi-generator.\n',
+    )
+    expect(readFile(rootPath, '.github/workflows/ci.yml')).toContain('@acme/i18n')
+  })
+
+  it('leaves the upgrade CLI, changelog, lockfile, and node_modules unchanged', () => {
+    const rootPath = createFixtureRoot()
+    writeFile(rootPath, '.boilerstone/package.json', '{"name":"@boilerstone/boilerplate"}\n')
+    writeFile(rootPath, 'CHANGELOG.md', '- Unify `@boilerstone/i18n` language keys\n')
+    writeFile(rootPath, 'pnpm-lock.yaml', "'@boilerstone/ui':\n")
+    writeFile(
+      rootPath,
+      'node_modules/@boilerstone/ui/index.js',
+      "export {} from '@boilerstone/ui'\n",
+    )
+    writeFile(rootPath, 'cli/setup.ts', "const oldPrefix = '@boilerstone'\n")
+
+    const actualCount = rewriteWorkspaceScope(rootPath, '@boilerstone', '@acme')
+
+    expect(actualCount).toBe(0)
+    expect(readFile(rootPath, '.boilerstone/package.json')).toContain('@boilerstone/boilerplate')
+    expect(readFile(rootPath, 'CHANGELOG.md')).toContain('@boilerstone/i18n')
+    expect(readFile(rootPath, 'pnpm-lock.yaml')).toContain('@boilerstone/ui')
+    expect(readFile(rootPath, 'node_modules/@boilerstone/ui/index.js')).toContain('@boilerstone/ui')
+    expect(readFile(rootPath, 'cli/setup.ts')).toBe("const oldPrefix = '@boilerstone'\n")
+  })
+
+  it('is a no-op when the project keeps the original scope', () => {
+    const rootPath = createFixtureRoot()
+    writeFile(rootPath, 'apps/web-spa/app/root.tsx', "import '@boilerstone/ui/globals.css'\n")
+
+    const actualCount = rewriteWorkspaceScope(rootPath, '@boilerstone', '@boilerstone')
+
+    expect(actualCount).toBe(0)
+    expect(readFile(rootPath, 'apps/web-spa/app/root.tsx')).toContain('@boilerstone/ui/globals.css')
+  })
+})

--- a/.boilerstone/docs/how-it-works.md
+++ b/.boilerstone/docs/how-it-works.md
@@ -46,7 +46,7 @@ curl -fsSL https://raw.githubusercontent.com/lonestone/lonestone-boilerplate/mai
 
 `--ref latest` is the default; pin with `--ref vX.Y.Z`. Branch refs like `main` are rejected so a project never starts from unreleased code. For a fork or private mirror, set `BOILERPLATE_REPO=<url>` — that repository must publish compatible `vX.Y.Z` tags.
 
-`bootstrap` adds the `boilerplate` script and a `tsx` devDependency, gitignores `.boilerstone/upgrade/`, switches `.boilerstone/` to consumer mode, and initializes tracking. It's idempotent and never overwrites what's already there. It deliberately does **not** run `pnpm rock` — that script renames packages and rewrites env/docker files, which is fine on a fresh template and destructive on a real project.
+`bootstrap` adds the `boilerplate` script and a `tsx` devDependency, gitignores `.boilerstone/upgrade/`, switches `.boilerstone/` to consumer mode, and initializes tracking. It's idempotent and never overwrites what's already there. It deliberately does **not** run `pnpm rock` — that script renames packages, rewrites leftover `@boilerstone/` imports, and rewrites env/docker files, which is fine on a fresh template and destructive on a real project.
 
 > **Heads-up on v1.0.0:** its intentions are baseline catch-ups ("align with the v1.0.0 …"), broader than the narrow deltas later releases ship. When onboarding an older project, budget roughly one working session per intention.
 

--- a/.boilerstone/migration-intentions/unreleased/rewrite-workspace-scope-imports.md
+++ b/.boilerstone/migration-intentions/unreleased/rewrite-workspace-scope-imports.md
@@ -1,0 +1,75 @@
+---
+id: unreleased/rewrite-workspace-scope-imports
+domain: tooling
+classification: migration
+---
+
+# Rewrite leftover @boilerstone imports
+
+## Goal
+
+After a project rename, workspace imports, tsconfig paths, shadcn aliases, docs, and CI filters use `@<project>/ui`, `@<project>/openapi-generator`, and `@<project>/i18n` — not `@boilerstone/`.
+
+## Why
+
+`pnpm rock` already renamed `package.json` names and dependency keys, but it left `@boilerstone/` in source, docs, and config. Vite then could not resolve `@boilerstone/ui` (and the other workspace packages) because those package names no longer existed. A tree-wide replace of the old scope, with a skip list for `.boilerstone/`, the changelog, and lockfiles, is the smallest way to keep every remaining reference in sync. Re-running `pnpm rock` is not the fix: it also rewrites env and docker files.
+
+## Applies When
+
+- The project tracks the `tooling` domain.
+- Workspace packages were renamed away from `@boilerstone/*` (for example `packages/ui/package.json` `"name"` is not `@boilerstone/ui`).
+- `apps/` or `packages/` still contain `@boilerstone/ui`, `@boilerstone/openapi-generator`, or `@boilerstone/i18n`. Still having those leftovers is the starting state this intention migrates away from, not a skip reason.
+
+## Do Not Apply When
+
+- The project still uses `@boilerstone` as its npm scope — record as skipped.
+- Those leftovers are already gone under `apps/` and `packages/`.
+- A human has explicitly decided to keep mixed scopes after reviewing this intention — record as skipped with that reason.
+
+## Observable Gaps
+
+1. **Frontend imports** — signal: `apps/web-spa` or `apps/web-ssr` still import `@boilerstone/ui`, `@boilerstone/openapi-generator`, or `@boilerstone/i18n`.
+   Read the current scope from `packages/ui/package.json` `"name"` (`@acme/ui` → `@acme`). Replace `@boilerstone/` with that scope in those apps. Do not touch `.boilerstone/`.
+   Done when: `rg "@boilerstone/(ui|openapi-generator|i18n)" apps/web-spa apps/web-ssr` returns nothing.
+
+2. **UI package self-references** — signal: `packages/ui` still imports `@boilerstone/ui`, or `packages/ui/tsconfig.json` / `packages/ui/components.json` still use that prefix.
+   Apply the same replace in `packages/ui`. Leave component implementations alone beyond the import/alias strings.
+   Done when: `rg "@boilerstone/" packages/ui` returns nothing.
+
+3. **i18n and OpenAPI package docs** — signal: `packages/i18n/README.md` or `packages/openapi-generator/README.md` still mention `@boilerstone/i18n` or `@boilerstone/openapi-generator`.
+   Adapt the scoped names from the staged references. Do not rewrite API usage examples beyond the package prefix.
+   Done when: those READMEs use the project's scope.
+
+4. **Documentation and CI** — signal: `apps/documentation` still cites `@boilerstone/ui` (or the other two packages), or `.github/workflows/ci.yml` still runs `pnpm --filter @boilerstone/i18n`.
+   Apply the same replace. Keep `.boilerstone/` and `CHANGELOG.md` unchanged.
+   Done when: `rg "@boilerstone/(ui|openapi-generator|i18n)" apps/documentation .github` returns nothing.
+
+5. **TypeScript path map** — signal: `tsconfig.base.json` still maps `"@boilerstone/*"`.
+   Rename that path key to the project's scope. Do not change the `packages/*/src` target.
+   Done when: the path key matches `@<project>/*`.
+
+## Out of Scope
+
+- Re-running `pnpm rock`.
+- `.boilerstone/` (the upgrade CLI stays `@boilerstone/boilerplate`).
+- `CHANGELOG.md` and lockfiles.
+- Root package name, docker-compose service names, and env files — those were already handled by rock.
+
+## Reference Paths
+
+- `cli/setup.ts` — **adapt**
+- `packages/ui/tsconfig.json` — **adapt**
+- `packages/ui/components.json` — **adapt**
+- `tsconfig.base.json` — **adapt**
+- `apps/documentation/src/content/docs/references/frontend.mdx` — **adapt**
+- `.github/workflows/ci.yml` — **adapt**
+
+## Validation
+
+- `rg "@boilerstone/(ui|openapi-generator|i18n)" apps packages --glob '!**/node_modules/**'` returns nothing.
+- `pnpm install` succeeds so the lockfile matches the renamed workspace packages.
+- `pnpm --filter=web-spa typecheck` and `pnpm --filter=web-ssr typecheck` pass when those apps exist (or the project's equivalent filters).
+
+## Record Result
+
+Run `pnpm boilerplate upgrade record --id unreleased/rewrite-workspace-scope-imports --applied` after validation passes, or record it as skipped with a reason. The id stays `unreleased/…` until the boilerplate release promotes it.

--- a/.boilerstone/migration-intentions/unreleased/rewrite-workspace-scope-imports.md
+++ b/.boilerstone/migration-intentions/unreleased/rewrite-workspace-scope-imports.md
@@ -2,6 +2,7 @@
 id: unreleased/rewrite-workspace-scope-imports
 domain: tooling
 classification: migration
+pr: 146
 ---
 
 # Rewrite leftover @boilerstone imports

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ pnpm rock
 
 The script will guide you through the configuration process interactively. It will:
 - Ask for your project name
-- Update package.json files for detected applications with the project name
+- Rename workspace packages to `@your-project/*` and rewrite remaining `@boilerstone/` imports in apps, packages, docs, tsconfig, and CI
 - Check for existing `.env` files and only prompt for missing variables
 - Automatically update all `.env` files with your configuration
 - Set up proper API URLs and trusted origins across all applications

--- a/apps/documentation/src/content/docs/quickstart.mdx
+++ b/apps/documentation/src/content/docs/quickstart.mdx
@@ -49,7 +49,7 @@ pnpm rock
 The script will guide you through the configuration process interactively. It will:
 
 - Ask for your project name
-- Update package.json files for detected applications with the project name
+- Rename workspace packages to `@your-project/*` and rewrite remaining `@boilerstone/` imports in apps, packages, docs, tsconfig, and CI
 - Check for existing `.env` files and only prompt for missing variables
 - Automatically update all `.env` files with your configuration
 - Set up proper API URLs and trusted origins across all applications

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, extname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import Enquirer from 'enquirer'
@@ -68,6 +68,7 @@ export const PRODUCER_FILES_TO_REMOVE = [
   '.boilerstone/cli/boilerplate-core.spec.ts',
   '.boilerstone/cli/tracking-state.spec.ts',
   '.boilerstone/cli/install.spec.ts',
+  '.boilerstone/cli/setup-rename.spec.ts',
   '.boilerstone/cli/vitest.setup.ts',
   '.boilerstone/vitest.config.ts',
   // Maintainer/onboarding-only skills; consumers keep only the boilerstone-upgrade skill
@@ -618,6 +619,93 @@ function updatePackageJsonDependencies(
   writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8')
 }
 
+const WORKSPACE_SCOPE_SKIP_DIRS = new Set([
+  '.astro',
+  '.boilerstone',
+  '.git',
+  '.output',
+  '.react-router',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+])
+
+const WORKSPACE_SCOPE_SKIP_FILES = new Set(['CHANGELOG.md', 'package-lock.json', 'pnpm-lock.yaml'])
+
+const WORKSPACE_SCOPE_TEXT_EXTENSIONS = new Set([
+  '.cjs',
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.jsx',
+  '.md',
+  '.mdc',
+  '.mdx',
+  '.mjs',
+  '.ts',
+  '.tsx',
+  '.yaml',
+  '.yml',
+])
+
+/**
+ * Replace `@old-scope/` with `@new-scope/` in project text files.
+ * Skips `.boilerstone/`, lockfiles, and the changelog so the upgrade CLI and
+ * historical records keep their own names.
+ */
+export function rewriteWorkspaceScope(
+  rootPath: string,
+  oldPrefix: string,
+  newPrefix: string,
+): number {
+  if (oldPrefix === newPrefix) {
+    return 0
+  }
+
+  const oldScoped = `${oldPrefix}/`
+  const newScoped = `${newPrefix}/`
+  let filesUpdated = 0
+
+  function walk(dirPath: string): void {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      if (entry.isSymbolicLink()) {
+        continue
+      }
+
+      if (entry.isDirectory()) {
+        if (WORKSPACE_SCOPE_SKIP_DIRS.has(entry.name)) {
+          continue
+        }
+        walk(join(dirPath, entry.name))
+        continue
+      }
+
+      if (!entry.isFile() || WORKSPACE_SCOPE_SKIP_FILES.has(entry.name)) {
+        continue
+      }
+
+      if (!WORKSPACE_SCOPE_TEXT_EXTENSIONS.has(extname(entry.name))) {
+        continue
+      }
+
+      const filePath = join(dirPath, entry.name)
+      const content = readFileSync(filePath, 'utf-8')
+      if (!content.includes(oldScoped)) {
+        continue
+      }
+
+      writeFileSync(filePath, content.replaceAll(oldScoped, newScoped), 'utf-8')
+      filesUpdated += 1
+    }
+  }
+
+  walk(rootPath)
+  return filesUpdated
+}
+
 function updateDockerCompose(projectName: string): void {
   const dockerComposePath = join(projectRoot, 'docker-compose.yml')
   if (!existsSync(dockerComposePath)) {
@@ -816,6 +904,13 @@ async function renameProjects(projectName: string, availableApps: AvailableApps)
     updatePackageJsonName(packagePath, `${newPrefix}/${name}`)
     updatePackageJsonDependencies(packagePath, oldPrefix, newPrefix)
     console.log(`  ${colorize('✓', 'green')} Updated ${colorize(path, 'dim')}`)
+  }
+
+  const rewrittenCount = rewriteWorkspaceScope(projectRoot, oldPrefix, newPrefix)
+  if (rewrittenCount > 0) {
+    console.log(
+      `  ${colorize('✓', 'green')} Rewrote ${colorize(String(rewrittenCount), 'bright')} files still referencing ${colorize(`${oldPrefix}/`, 'dim')}`,
+    )
   }
 
   console.log(
@@ -1044,7 +1139,7 @@ async function main(): Promise<void> {
     // Prompt for project name
     const projectName = await prompt('Project name', 'my-project')
 
-    // Update package.json files for detected applications with the project name
+    // Rename workspace packages and rewrite leftover @boilerstone/ imports
     await renameProjects(projectName, availableApps)
 
     // Prompt for configuration BEFORE copying files


### PR DESCRIPTION
pnpm rock already renamed workspace package.json names and dependency keys, but source imports, tsconfig paths, shadcn aliases, docs, and CI filters still pointed at `@boilerstone/ui`, `@boilerstone/openapi-generator`, and `@boilerstone/i18n`. After a rename those packages no longer existed under the old scope, so the frontend apps could not start. A tree-wide replace of `@boilerstone/`, skipping `.boilerstone/`, the changelog, and lockfiles, keeps every remaining reference in sync without re-running the rest of rock.

Fixes #106

feat(boilerstone): add an unreleased intention to rewrite leftover @boilerstone imports