### PR TITLE
fix(tooling): keep the OpenAPI generator on the /api prefix

### DIFF
--- a/.boilerstone/migration-intentions/unreleased/openapi-generator-docs-url.md
+++ b/.boilerstone/migration-intentions/unreleased/openapi-generator-docs-url.md
@@ -1,0 +1,74 @@
+---
+id: unreleased/openapi-generator-docs-url
+domain: tooling
+classification: migration
+---
+
+# Point the OpenAPI generator at /api/docs.json
+
+## Goal
+
+The OpenAPI generator waits on and fetches `${API_URL}/docs.json`, and `API_URL` already includes the API global prefix (`http://localhost:<port>/api`). A missing spec fails loudly instead of writing a 404 body to `tmp/openapi.json`.
+
+## Why
+
+Issue 94 already moved the `/api` prefix into `API_URL` and left the fetch path as `/docs.json`. `pnpm rock` then overwrote that env without the prefix, so generate hit `/docs.json` at the host root and saved a Nest 404 JSON. `@hey-api/openapi-ts` reported that as `Unsupported OpenAPI specification`. The `dev` script still waited on Nest swagger's old `/docs-json` path. Hardcoding `/api/docs.json` on top of `API_URL` would double the prefix whenever `.env.example` is used as-is.
+
+## Applies When
+
+- The project tracks the `tooling` domain, or `packages/openapi-generator/` exists.
+- `packages/openapi-generator/.env` has an `API_URL` that does not end with `/api`, or the `dev` script still waits on `/docs-json`, or preprocess fetches `${API_URL}/api/docs.json`. Still having any of those is the starting state this intention migrates away from, not a skip reason.
+
+## Do Not Apply When
+
+- The project has no `packages/openapi-generator/` package — record as skipped.
+- The API serves the OpenAPI document at a custom path that is not `/api/docs.json` — stop and ask rather than rewriting URLs.
+- A human has explicitly decided to keep a different generator URL after reviewing this intention — record as skipped with that reason.
+
+## Observable Gaps
+
+1. **Generator env prefix** — signal: `packages/openapi-generator/.env` (or `.env.example`) has `API_URL=http://localhost:<port>` with no trailing `/api`.
+   Set `API_URL` to `http://localhost:<port>/api`, matching the staged reference `packages/openapi-generator/.env.example`. Do not change frontend `VITE_API_URL` values; those stay at the host origin.
+   Done when: `API_URL` ends with `/api` and `${API_URL}/docs.json` is `http://localhost:<port>/api/docs.json`.
+
+2. **wait-on path** — signal: `packages/openapi-generator/package.json` `dev` script contains `/docs-json`.
+   Change it to `wait-on ${API_URL}/docs.json`. Do not insert an extra `/api` in that path.
+   Done when: `rg docs-json packages/openapi-generator/package.json` returns nothing.
+
+3. **preprocess fetch** — signal: `packages/openapi-generator/preprocess/index.js` fetches `${process.env.API_URL}/api/docs.json`, or it calls `res.json()` without checking `res.ok`.
+   Keep `${process.env.API_URL}/docs.json` and throw if `!res.ok`, matching the staged reference. Do not add `/api` to the path.
+   Done when: the fetch URL is `${process.env.API_URL}/docs.json` and a non-OK response throws before writing `tmp/openapi.json`.
+
+4. **rock overwrite** — signal: `cli/setup.ts` writes OpenAPI `API_URL` as `http://localhost:${config.ports.api}` with no `/api`.
+   Append `/api` when writing `packages/openapi-generator/.env`, matching the staged reference. Leave web-spa and web-ssr `VITE_API_URL` without the prefix.
+   Done when: the OpenAPI generator branch of `cli/setup.ts` writes a URL ending in `/api`.
+
+5. **Generator docs** — signal: `packages/openapi-generator/README.md` or `apps/documentation/src/content/docs/guides/generating-types.mdx` still mentions `/docs-json`, or they do not say that `API_URL` already includes `/api`.
+   Adapt the short URL notes from the staged references. Do not rewrite the rest of those pages.
+   Done when: neither file mentions `/docs-json`, and generating-types states that `API_URL` includes the `/api` prefix.
+
+## Out of Scope
+
+- Frontend `VITE_API_URL` and the generated client `baseURL`.
+- The API global prefix in `apps/api/src/main.ts`, Scalar setup, and the `/api/docs` UI.
+- Regenerating `packages/openapi-generator/client/` or `tmp/openapi.json`.
+- Moving the OpenAPI document off `/api/docs.json`.
+
+## Reference Paths
+
+- `packages/openapi-generator/.env.example` — **copy**
+- `packages/openapi-generator/package.json` — **adapt**
+- `packages/openapi-generator/preprocess/index.js` — **adapt**
+- `cli/setup.ts` — **adapt**
+- `packages/openapi-generator/README.md` — **adapt**
+- `apps/documentation/src/content/docs/guides/generating-types.mdx` — **adapt**
+
+## Validation
+
+- `packages/openapi-generator/.env` `API_URL` ends with `/api`.
+- With the API running, `pnpm generate` writes a real OpenAPI document to `tmp/openapi.json` (it contains `openapi`, not a Nest 404 body).
+- `rg docs-json packages/openapi-generator` returns nothing in `package.json` or `README.md`.
+
+## Record Result
+
+Run `pnpm boilerplate upgrade record --id unreleased/openapi-generator-docs-url --applied` after validation passes, or record it as skipped with a reason. The id stays `unreleased/…` until the boilerplate release promotes it.

--- a/.boilerstone/migration-intentions/unreleased/openapi-generator-docs-url.md
+++ b/.boilerstone/migration-intentions/unreleased/openapi-generator-docs-url.md
@@ -2,6 +2,7 @@
 id: unreleased/openapi-generator-docs-url
 domain: tooling
 classification: migration
+pr: 147
 ---
 
 # Point the OpenAPI generator at /api/docs.json

--- a/apps/documentation/src/content/docs/guides/generating-types.mdx
+++ b/apps/documentation/src/content/docs/guides/generating-types.mdx
@@ -7,6 +7,8 @@ description: Generate types and SDKs from the OpenAPI schema
 
 For the types to be generated, you need to have the OpenAPI schema available. Which means your **API needs to be running without errors**.
 
+The generator fetches `${API_URL}/docs.json`. `API_URL` in `packages/openapi-generator/.env` must include the API global prefix, for example `http://localhost:3000/api`. Do not add a second `/api` in the fetch path.
+
 You can generate the types by running the following command (at root level):
 
 ```bash

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -1053,7 +1053,8 @@ function updateAllEnvFiles(config: EnvConfig, availableApps: AvailableApps): voi
   // OpenAPI Generator .env
   if (availableApps.openapiGenerator && config.ports.api) {
     const openapiEnvPath = join(projectRoot, 'packages/openapi-generator/.env')
-    const apiUrl = `http://localhost:${config.ports.api}`
+    // Includes the API global prefix: preprocess fetches `${API_URL}/docs.json`.
+    const apiUrl = `http://localhost:${config.ports.api}/api`
     updateEnvFile(openapiEnvPath, { API_URL: apiUrl }, false)
   }
 

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -11,7 +11,7 @@ L'OpenAPI Generator a plusieurs objectifs clés :
 - **Productivité** : Réduction du code boilerplate et des erreurs de typage
 - **Documentation** : Fournit une documentation implicite des endpoints disponibles
 
-Le générateur utilise l'outil `@hey-api/openapi-ts` pour transformer la spécification OpenAPI (récupérée depuis l'URL http://localhost:3000/docs-json) en un client TypeScript fortement typé avec validation Zod.
+Le générateur utilise l'outil `@hey-api/openapi-ts` pour transformer la spécification OpenAPI (récupérée depuis `${API_URL}/docs.json`, `API_URL` incluant le préfixe `/api`) en un client TypeScript fortement typé avec validation Zod.
 
 ## Usage
 
@@ -47,7 +47,7 @@ Les packages suivants dépendent d'OpenAPI Generator :
 
 La configuration se trouve dans le fichier `openapi-ts.config.ts`. Elle définit :
 
-- La source du schéma OpenAPI (endpoint `/docs-json` de l'API NestJS)
+- La source du schéma OpenAPI (endpoint `/docs.json` de l'API NestJS, sous le préfixe `/api`)
 - Les formats de sortie et les plugins utilisés
 - Les transformations appliquées aux données (ex: conversion des dates)
 

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -10,7 +10,7 @@
     "./client/core/*": "./client/core/*.ts"
   },
   "scripts": {
-    "dev": "dotenvx run -- wait-on ${API_URL}/docs-json && pnpm generate --watch",
+    "dev": "dotenvx run -- wait-on ${API_URL}/docs.json && pnpm generate --watch",
     "preprocess": "node ./preprocess/index.js",
     "generate": "cross-env dotenvx run -- pnpm preprocess && dotenvx run -- openapi-ts -f ./openapi-ts.config.ts"
   },

--- a/packages/openapi-generator/preprocess/index.js
+++ b/packages/openapi-generator/preprocess/index.js
@@ -13,6 +13,9 @@ async function main() {
   const url = `${process.env.API_URL}/docs.json`
   const tmp = path.resolve('tmp', 'openapi.json')
   const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch OpenAPI spec from ${url}: ${res.status} ${res.statusText}`)
+  }
   const spec = await res.json()
 
   spec.components = spec.components || {}


### PR DESCRIPTION
Issue 94 already put `/api` in `API_URL` and left the fetch path as `/docs.json`. Issue 113's suggested `${API_URL}/api/docs.json` would 404 against `.env.example`. The remaining holes were `pnpm rock` rewriting `API_URL` back to the host origin, and the `dev` script still waiting on Nest swagger's `/docs-json`. A non-OK fetch now throws instead of writing a 404 body that `@hey-api/openapi-ts` reports as an unsupported spec.

Fixes #113

feat(boilerstone): add an unreleased intention for the OpenAPI generator docs URL

Made with [Cursor](https://cursor.com)