### PR TITLE
docs(api): show wrap.assign on comment updates

### DIFF
--- a/apps/api/src/modules/example/comments/comments.controller.ts
+++ b/apps/api/src/modules/example/comments/comments.controller.ts
@@ -26,6 +26,8 @@ import {
   commentsSchema,
   CreateCommentInput,
   createCommentSchema,
+  UpdateCommentInput,
+  updateCommentSchema,
 } from './contracts/comments.contract'
 
 @TypedController(
@@ -48,6 +50,23 @@ export class CommentsController {
   ): Promise<CommentResponse> {
     const userId = session?.user?.id
     const comment = await this.commentsService.createComment(postSlug, body, userId)
+    return this.commentsMapper.toComment(comment)
+  }
+
+  @TypedRoute.Patch(':commentId', commentSchema)
+  @UseGuards(AuthGuard)
+  async updateComment(
+    @TypedParam('postSlug', z.string()) postSlug: string,
+    @TypedParam('commentId', z.string()) commentId: string,
+    @TypedBody(updateCommentSchema) body: UpdateCommentInput,
+    @Session() session: { user: { id: string } },
+  ): Promise<CommentResponse> {
+    const comment = await this.commentsService.updateComment(
+      postSlug,
+      commentId,
+      session.user.id,
+      body,
+    )
     return this.commentsMapper.toComment(comment)
   }
 

--- a/apps/api/src/modules/example/comments/comments.service.ts
+++ b/apps/api/src/modules/example/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager, FilterQuery, QueryOrderMap } from '@mikro-orm/core'
+import { EntityManager, FilterQuery, QueryOrderMap, wrap } from '@mikro-orm/core'
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { User } from '../../auth/auth.entity'
 import { buildOrderBy } from '../../db/query-order.util'
@@ -9,6 +9,7 @@ import {
   CommentPagination,
   CommentSorting,
   CreateCommentInput,
+  UpdateCommentInput,
 } from './contracts/comments.contract'
 
 export interface CommentsResult {
@@ -55,6 +56,27 @@ export class CommentsService {
     this.em.persist(comment)
     await this.em.flush()
 
+    return comment
+  }
+
+  async updateComment(
+    postSlug: string,
+    commentId: string,
+    userId: string,
+    data: UpdateCommentInput,
+  ): Promise<Comment> {
+    const comment = await this.em.findOne(
+      Comment,
+      { id: commentId, post: { slug: postSlug } },
+      { populate: ['user'] },
+    )
+    if (!comment) throw new NotFoundException('Comment not found')
+    if (!comment.user || comment.user.id !== userId) {
+      throw new ForbiddenException('Only the comment author can update this comment')
+    }
+
+    wrap(comment).assign(data)
+    await this.em.flush()
     return comment
   }
 

--- a/apps/api/src/modules/example/comments/contracts/comments.contract.ts
+++ b/apps/api/src/modules/example/comments/contracts/comments.contract.ts
@@ -19,6 +19,17 @@ export const createCommentSchema = z
 
 export type CreateCommentInput = z.infer<typeof createCommentSchema>
 
+export const updateCommentSchema = z
+  .object({
+    content: z.string().min(1).max(1000),
+  })
+  .meta({
+    title: 'UpdateCommentSchema',
+    description: 'Schema for updating a comment',
+  })
+
+export type UpdateCommentInput = z.infer<typeof updateCommentSchema>
+
 // Schema for comment response
 // Using a simpler approach to avoid recursive type issues
 export const commentSchema = z

--- a/apps/api/src/modules/example/comments/tests/comments.controller.e2e-spec.ts
+++ b/apps/api/src/modules/example/comments/tests/comments.controller.e2e-spec.ts
@@ -1,0 +1,133 @@
+import { EntityManager } from '@mikro-orm/core'
+import { beforeEach, describe, expect, it } from 'vitest'
+/**
+ * E2E Tests for CommentsController
+ *
+ * Tests the following endpoints:
+ * - PATCH /posts/:postSlug/comments/:commentId - Update a comment (author only)
+ * - Auth guard behavior (401 when unauthenticated)
+ */
+import type { BetterAuthSession } from '../../../auth/auth.config'
+import type { User } from '../../../auth/auth.entity'
+import { initializeTestApp } from '../../../../test/helpers/test-app.helper'
+import { createRequest, TestRequest } from '../../../../test/helpers/test-auth.helper'
+import { createUserWithSession } from '../../../../test/helpers/test-user.helpers'
+import { Post } from '../../posts/posts.entity'
+import { PostModule } from '../../posts/posts.module'
+import { CommentsModule } from '../comments.module'
+import { Comment } from '../comments.entity'
+
+async function createPublishedPost(
+  request: TestRequest,
+  session: BetterAuthSession,
+  title: string,
+): Promise<{ slug: string }> {
+  const createResponse = await request
+    .withSession(session)
+    .post('/admin/posts')
+    .send({
+      title,
+      content: [{ type: 'text', data: 'Post body' }],
+    })
+  const postId = createResponse.body.id as string
+  const publishResponse = await request.withSession(session).patch(`/admin/posts/${postId}/publish`)
+  return { slug: publishResponse.body.slug as string }
+}
+
+async function createCommentOnPost(
+  em: EntityManager,
+  slug: string,
+  content: string,
+  user?: User,
+): Promise<Comment> {
+  const post = await em.findOneOrFail(Post, { slug })
+  const comment = new Comment()
+  comment.post = post
+  comment.content = content
+  if (user) {
+    comment.user = user
+  } else {
+    comment.authorName = 'Anonymous'
+  }
+  em.persist(comment)
+  await em.flush()
+  return comment
+}
+
+describe('commentsController (e2e)', () => {
+  beforeEach(async (context) => {
+    const { orm, app } = await initializeTestApp(
+      { orm: context.orm },
+      {
+        imports: [PostModule, CommentsModule],
+      },
+    )
+    context.app = app
+    context.em = orm.em.fork()
+    context.request = createRequest(app)
+  })
+
+  describe('pATCH /posts/:postSlug/comments/:commentId', () => {
+    it('should update the comment when the author is authenticated', async (context) => {
+      const { em, request } = context
+      const { user, session } = await createUserWithSession(em)
+      const { slug } = await createPublishedPost(request, session, 'Author Post')
+      const comment = await createCommentOnPost(em, slug, 'Original comment', user)
+
+      const response = await request
+        .withSession(session)
+        .patch(`/posts/${slug}/comments/${comment.id}`)
+        .send({ content: 'Updated comment' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject({
+        id: comment.id,
+        content: 'Updated comment',
+      })
+    })
+
+    it('should return 403 when another user tries to update the comment', async (context) => {
+      const { em, request } = context
+      const { user: author, session: authorSession } = await createUserWithSession(em, {
+        name: 'Author',
+      })
+      const { session: otherSession } = await createUserWithSession(em, { name: 'Other' })
+      const { slug } = await createPublishedPost(request, authorSession, 'Shared Post')
+      const comment = await createCommentOnPost(em, slug, 'Author comment', author)
+
+      const response = await request
+        .withSession(otherSession)
+        .patch(`/posts/${slug}/comments/${comment.id}`)
+        .send({ content: 'Hijacked comment' })
+
+      expect(response.status).toBe(403)
+    })
+
+    it('should return 403 when updating an anonymous comment', async (context) => {
+      const { em, request } = context
+      const { session } = await createUserWithSession(em)
+      const { slug } = await createPublishedPost(request, session, 'Anonymous Post')
+      const comment = await createCommentOnPost(em, slug, 'Anonymous comment')
+
+      const response = await request
+        .withSession(session)
+        .patch(`/posts/${slug}/comments/${comment.id}`)
+        .send({ content: 'Edited anonymous comment' })
+
+      expect(response.status).toBe(403)
+    })
+
+    it('should return 401 when unauthenticated', async (context) => {
+      const { em, request } = context
+      const { user, session } = await createUserWithSession(em)
+      const { slug } = await createPublishedPost(request, session, 'Guard Post')
+      const comment = await createCommentOnPost(em, slug, 'Original comment', user)
+
+      const response = await request.patch(`/posts/${slug}/comments/${comment.id}`).send({
+        content: 'Updated comment',
+      })
+
+      expect(response.status).toBe(401)
+    })
+  })
+})

--- a/apps/documentation/src/content/docs/explanations/5_orm.mdx
+++ b/apps/documentation/src/content/docs/explanations/5_orm.mdx
@@ -63,6 +63,29 @@ Some important concepts to know:
 - MikroORM NestJS module automatically creates a new Context for each request, you don't need to do anything special to get it. But if you want to use some functions outside of a request — for example in a CRON job — you will need to create a new Context manually (or use the `EnsureRequestContext` decorator).
 - Deprecated methods removed in v7: use `em.persist(entity)` + `await em.flush()` instead of `em.persistAndFlush(entity)`, `em.remove(entity)` + `await em.flush()` instead of `em.removeAndFlush(entity)`, and `orm.schema.refresh()` instead of `orm.schema.refreshDatabase()`. Decorators are now imported from `@mikro-orm/decorators/legacy` instead of `@mikro-orm/core`.
 
+### Updating an entity
+
+`wrap(entity).assign(data)` is the usual way to copy fields onto a loaded entity. It respects the entity graph (scalars, foreign keys, nested relations) instead of assigning properties by hand. See MikroORM's [entity helper](https://mikro-orm.io/docs/entity-helper).
+
+The copy-paste example is `CommentsService.updateComment` in `apps/api/src/modules/example/comments/comments.service.ts`:
+
+```typescript
+wrap(comment).assign(data)
+await this.em.flush()
+```
+
+In most cases, you will pass the entire update DTO to `assign`.
+
+Pass `{ em }` when the payload contains relations as ids (or nested creates). Without the entity manager, MikroORM cannot turn those ids into references:
+
+```typescript
+wrap(event).assign({ title: data.title, venue: { id: data.venueId } }, { em: this.em })
+```
+
+Use `mergeObjectProperties: true` when you want nested object fields merged instead of replaced.
+
+Do not assign a whole DTO onto an entity whose fields live elsewhere. The posts example is versioned on purpose: `title` and `content` live on `PostVersion`, and tags arrive as names that must be resolved. `wrap(post).assign(updateDto)` would silently skip those fields. Assign only what belongs on that entity; keep versioning and collection rebuilds as explicit steps.
+
 :::note [About migrations]
 Migrations are an important part of database management, you can read more about them in the [Database Migrations](/lonestone-boilerplate/explanations/6_database-migrations) page.
 :::


### PR DESCRIPTION
Issue 108 asked for a wrap().assign() example so people and LLMs copy MikroORM's usual update path. Post is a bad naive target: title and content live on PostVersion, tags arrive as names, and publish creates a new version. wrap(post).assign(dto) would silently skip those fields.

The live example is therefore CommentsService.updateComment (author-only PATCH). The ORM page documents assign, { em } for relations-by-id, mergeObjectProperties, and why posts stay field-by-field.

Closes #108