### PR TITLE
fix(auth): resolve a context-safe entity manager in the MikroORM adapter

### DIFF
--- a/.boilerstone/migration-intentions/unreleased/auth-adapter-request-context.md
+++ b/.boilerstone/migration-intentions/unreleased/auth-adapter-request-context.md
@@ -1,0 +1,66 @@
+---
+id: unreleased/auth-adapter-request-context
+domain: auth
+classification: migration
+---
+
+# Auth Adapter Request Context
+
+## Goal
+
+Every operation of the local Better Auth MikroORM adapter (`apps/api/src/modules/auth/auth-db.adapter.ts`) runs on a context-safe entity manager: the contextual one inside a request, a dedicated fork outside one.
+
+## Why
+
+The adapter called `orm.em` directly. Inside an HTTP handler that resolves to the request-scoped fork through the MikroORM Nest middleware, so it worked. Outside one it stays the global instance, and MikroORM refuses context-specific work with `Using global EntityManager instance methods for context specific actions is disallowed`.
+
+Better Auth is not only called from HTTP handlers. A WebSocket gateway resolving a session from the upgrade request, a scheduled task, or a queue worker all reach the adapter with no ambient context, and every query throws. Raising `allowGlobalContext` would silence the error by sharing one identity map across concurrent callers, which is what the option exists to prevent.
+
+The entity manager is resolved once per adapter operation, not once per call site, so `persist` and `flush` stay on the same instance.
+
+## Applies When
+
+- The project uses Better Auth on the local MikroORM adapter (`v1.0.0/align-better-auth-mikro-orm-adapter` applied, or `auth-db.adapter.ts` present).
+- `auth-db.adapter.ts` calls `orm.em` inside its adapter operations, or `normalizeInput` calls `orm.em.getReference`.
+
+## Do Not Apply When
+
+- The project has no API app, or does not use Better Auth.
+- Auth persistence is not the local MikroORM adapter (a `pg` pool, Drizzle, Prisma) — that is `v1.0.0/align-better-auth-mikro-orm-adapter`, not this intention.
+- The project deliberately runs the ORM with `allowGlobalContext: true` and a human confirms it wants to keep the global identity map — record as skipped with that reason.
+
+## Observable Gaps
+
+1. **Entity manager resolution** — signal: `auth-db.adapter.ts` has no helper resolving the entity manager, and grepping it for `orm.em` returns hits outside a single `fork()` call.
+   Add the `resolveEntityManager` helper from the staged reference and call it once at the top of `count`, `create`, `delete`, `deleteMany`, `findMany`, `findOne`, `update` and `updateMany`. Keep the project's own adapter deltas (entity-name overrides, extra options).
+   Done when: the only `orm.em` left in the file is inside the helper.
+
+2. **Reference creation** — signal: `normalizeInput` in `createAdapterUtils` calls `orm.em.getReference`.
+   Thread the operation's entity manager through `normalizeInput` as in the staged reference. `getReference` touches the identity map, so it throws on the global instance like any other operation.
+   Done when: `normalizeInput` takes an entity manager and `createAdapterUtils` no longer closes over `orm.em`.
+
+3. **Write consistency** — signal: `create`, `update` or `delete` call `persist`, `assign`, `remove` and `flush` on separately resolved managers.
+   Resolve once per operation and reuse that instance for the whole operation.
+   Done when: each operation body references a single `em` binding.
+
+## Out of Scope
+
+- The adapter's query translation: where clauses, select, sort, and output serialization.
+- Which entities back which Better Auth model, and the Better Auth configuration itself.
+- Adding `allowGlobalContext` to the ORM configuration.
+- Wrapping non-HTTP entry points in a request context, which stays the application's call.
+
+## Reference Paths
+
+- `apps/api/src/modules/auth/auth-db.adapter.ts` — **adapt**
+
+## Validation
+
+- `pnpm --filter=api typecheck` passes.
+- Auth adapter tests pass if available.
+- Grepping `auth-db.adapter.ts` for `orm.em` returns only the helper's `fork()` call.
+- A Better Auth call made outside any request context (a WebSocket handler, a scheduled task) reads and writes without the global-context error, with `allowGlobalContext` unset.
+
+## Record Result
+
+Run `pnpm boilerplate upgrade record --id unreleased/auth-adapter-request-context --applied` after validation passes, or record it as skipped with a reason. The id stays `unreleased/…` until the boilerplate release promotes it.

--- a/.boilerstone/migration-intentions/unreleased/auth-adapter-request-context.md
+++ b/.boilerstone/migration-intentions/unreleased/auth-adapter-request-context.md
@@ -8,20 +8,22 @@ classification: migration
 
 ## Goal
 
-Every operation of the local Better Auth MikroORM adapter (`apps/api/src/modules/auth/auth-db.adapter.ts`) runs on a context-safe entity manager: the contextual one inside a request, a dedicated fork outside one.
+Every database operation of the local Better Auth MikroORM adapter (`apps/api/src/modules/auth/auth-db.adapter.ts`) runs under `@EnsureRequestContext()`, so `orm.em` resolves to a usable fork whether or not the caller has an ambient MikroORM context.
 
 ## Why
 
 The adapter called `orm.em` directly. Inside an HTTP handler that resolves to the request-scoped fork through the MikroORM Nest middleware, so it worked. Outside one it stays the global instance, and MikroORM refuses context-specific work with `Using global EntityManager instance methods for context specific actions is disallowed`.
 
-Better Auth is not only called from HTTP handlers. A WebSocket gateway resolving a session from the upgrade request, a scheduled task, or a queue worker all reach the adapter with no ambient context, and every query throws. Raising `allowGlobalContext` would silence the error by sharing one identity map across concurrent callers, which is what the option exists to prevent.
+Better Auth is not only called from HTTP handlers. A WebSocket gateway resolving a session from the upgrade request, a scheduled task, or a queue worker all reach the adapter with no ambient context, and every query throws. Raising `allowGlobalContext` would silence the error by sharing one identity map across concurrent callers, which is what the option exists to prevent. Wrapping each non-HTTP entry point in a request context puts the burden on every call site, and an adapter that only works under one kind of caller is the thing to fix.
 
-The entity manager is resolved once per adapter operation, not once per call site, so `persist` and `flush` stay on the same instance.
+MikroORM ships the decorator for exactly this: `@EnsureRequestContext()` reuses the request fork when there is one, prefers the surrounding `TransactionContext` when the call happens inside `em.transactional` (a hand-rolled `RequestContext.getEntityManager() ?? orm.em.fork()` forks alongside the transaction instead of joining it), and opens a context for the operation otherwise. Inside the method `orm.em` then resolves to that one fork for the whole body, so `persist` and `flush` stay on the same instance and `normalizeInput` does not need the manager threaded in.
+
+The decorator only applies to class members, so the adapter operations move off the object literal returned by `adapter(config)` onto a class. `createAdapterFactory` calls them as methods, so `this` is preserved and the factory needs no change beyond `adapter: (config) => new MikroOrmAuthAdapter(orm, config)`.
 
 ## Applies When
 
 - The project uses Better Auth on the local MikroORM adapter (`v1.0.0/align-better-auth-mikro-orm-adapter` applied, or `auth-db.adapter.ts` present).
-- `auth-db.adapter.ts` calls `orm.em` inside its adapter operations, or `normalizeInput` calls `orm.em.getReference`.
+- The adapter operations in `auth-db.adapter.ts` are not wrapped in `@EnsureRequestContext()`: they call `orm.em` directly, or go through a hand-rolled helper resolving the entity manager.
 
 ## Do Not Apply When
 
@@ -31,17 +33,17 @@ The entity manager is resolved once per adapter operation, not once per call sit
 
 ## Observable Gaps
 
-1. **Entity manager resolution** — signal: `auth-db.adapter.ts` has no helper resolving the entity manager, and grepping it for `orm.em` returns hits outside a single `fork()` call.
-   Add the `resolveEntityManager` helper from the staged reference and call it once at the top of `count`, `create`, `delete`, `deleteMany`, `findMany`, `findOne`, `update` and `updateMany`. Keep the project's own adapter deltas (entity-name overrides, extra options).
-   Done when: the only `orm.em` left in the file is inside the helper.
+1. **Adapter shape** — signal: the `adapter(config)` callback in `mikroOrmAdapter` returns an object literal of operations.
+   Move the operations onto a `MikroOrmAuthAdapter` class as in the staged reference: the constructor takes `(orm, config)`, keeps `orm` on a property (the decorator resolves the entity manager from `this.orm`) and builds the utils once. `adapter` becomes `(config) => new MikroOrmAuthAdapter(orm, config)`. Keep the project's own adapter deltas (entity-name overrides, extra options).
+   Done when: `createAdapterFactory` receives a class instance and no operation lives on an object literal.
 
-2. **Reference creation** — signal: `normalizeInput` in `createAdapterUtils` calls `orm.em.getReference`.
-   Thread the operation's entity manager through `normalizeInput` as in the staged reference. `getReference` touches the identity map, so it throws on the global instance like any other operation.
-   Done when: `normalizeInput` takes an entity manager and `createAdapterUtils` no longer closes over `orm.em`.
+2. **Context resolution** — signal: an operation body resolves an entity manager itself (`RequestContext.getEntityManager()`, `orm.em.fork()`, or a local `resolveEntityManager` helper), or none of the operations carry a decorator.
+   Decorate `count`, `create`, `delete`, `deleteMany`, `findMany`, `findOne`, `update` and `updateMany` with `@EnsureRequestContext()` from `@mikro-orm/decorators/legacy` and drop the helper. `createSchema` stays undecorated: it only reads metadata and writes files.
+   Done when: the file imports `EnsureRequestContext`, every database operation carries it, and no `fork()` or `RequestContext` call is left.
 
-3. **Write consistency** — signal: `create`, `update` or `delete` call `persist`, `assign`, `remove` and `flush` on separately resolved managers.
-   Resolve once per operation and reuse that instance for the whole operation.
-   Done when: each operation body references a single `em` binding.
+3. **Reference creation** — signal: `normalizeInput` in `createAdapterUtils` takes an entity manager parameter, or the file threads one through to `getReference`.
+   Under the decorator `orm.em` is already the contextual fork, so `normalizeInput` closes over `orm` like the rest of `createAdapterUtils` and calls `orm.em.getReference`.
+   Done when: `normalizeInput` takes `(metadata, input)` only.
 
 ## Out of Scope
 
@@ -49,6 +51,7 @@ The entity manager is resolved once per adapter operation, not once per call sit
 - Which entities back which Better Auth model, and the Better Auth configuration itself.
 - Adding `allowGlobalContext` to the ORM configuration.
 - Wrapping non-HTTP entry points in a request context, which stays the application's call.
+- Services and gateways elsewhere in the project that resolve their own entity manager — this intention covers the auth adapter only.
 
 ## Reference Paths
 
@@ -57,8 +60,8 @@ The entity manager is resolved once per adapter operation, not once per call sit
 ## Validation
 
 - `pnpm --filter=api typecheck` passes.
-- Auth adapter tests pass if available.
-- Grepping `auth-db.adapter.ts` for `orm.em` returns only the helper's `fork()` call.
+- `pnpm --filter=api test` passes.
+- Grepping `auth-db.adapter.ts` for `RequestContext` or `fork(` returns nothing.
 - A Better Auth call made outside any request context (a WebSocket handler, a scheduled task) reads and writes without the global-context error, with `allowGlobalContext` unset.
 
 ## Record Result

--- a/apps/api/src/modules/auth/auth-db.adapter.ts
+++ b/apps/api/src/modules/auth/auth-db.adapter.ts
@@ -1,5 +1,6 @@
 import type {
   EntityData,
+  EntityManager,
   EntityMetadata,
   EntityName,
   EntityProperty,
@@ -11,7 +12,7 @@ import type { BetterAuthOptions } from 'better-auth'
 import type { CleanedWhere, DBAdapterDebugLogOption } from 'better-auth/adapters'
 import type { DBFieldAttribute } from 'better-auth/db'
 import { writeFileSync } from 'node:fs'
-import { ReferenceKind, serialize } from '@mikro-orm/core'
+import { ReferenceKind, RequestContext, serialize } from '@mikro-orm/core'
 import { BetterAuthError } from 'better-auth'
 import { createAdapterFactory } from 'better-auth/adapters'
 import { getAuthTables } from 'better-auth/db'
@@ -109,6 +110,16 @@ function throwAdapterError(message: string): never {
   throw new BetterAuthError(`[MikroORM Adapter] ${message}`)
 }
 
+// Better Auth is not only called from HTTP handlers. A WebSocket gateway, a
+// scheduled task or a queue worker has no ambient MikroORM context, and
+// `orm.em` refuses context-specific work when it is the global instance. Take
+// the contextual entity manager when there is one, a dedicated fork otherwise.
+// One call per adapter operation, so persist and flush stay on the same
+// instance.
+function resolveEntityManager(orm: MikroORM): EntityManager {
+  return RequestContext.getEntityManager() ?? orm.em.fork()
+}
+
 const OWN_REFERENCES: ReadonlySet<ReferenceKind> = new Set([
   ReferenceKind.SCALAR,
   ReferenceKind.ONE_TO_MANY,
@@ -122,7 +133,11 @@ interface AdapterUtils {
     fieldName: string,
     throwOnShadowProps?: boolean,
   ) => string[]
-  normalizeInput: (metadata: AuthEntityMetadata, input: AuthRecord) => AuthEntityData
+  normalizeInput: (
+    em: EntityManager,
+    metadata: AuthEntityMetadata,
+    input: AuthRecord,
+  ) => AuthEntityData
   normalizeOutput: (
     metadata: AuthEntityMetadata,
     output: AuthModelEntity,
@@ -235,14 +250,14 @@ export function createAdapterUtils(
     )
   }
 
-  const normalizeInput: AdapterUtils['normalizeInput'] = (metadata, input) => {
+  const normalizeInput: AdapterUtils['normalizeInput'] = (em, metadata, input) => {
     const fields: PathRecord = {}
 
     for (const [key, value] of Object.entries(input)) {
       const prop = getPropertyMetadata(metadata, key)
       const normalizedValue =
         prop.targetMeta && !OWN_REFERENCES.has(prop.kind)
-          ? orm.em.getReference(prop.targetMeta.class as EntityName<AuthModelEntity>, value)
+          ? em.getReference(prop.targetMeta.class as EntityName<AuthModelEntity>, value)
           : value
 
       setPath(fields, [prop.name], normalizedValue)
@@ -440,18 +455,20 @@ export function mikroOrmAdapter(
 
       return {
         async count({ model, where }: AdapterQueryParams): Promise<number> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
 
-          return orm.em.count(metadata.class, normalizeWhereClauses(metadata, where))
+          return em.count(metadata.class, normalizeWhereClauses(metadata, where))
         },
 
         async create<T>({ data, model, select }: AdapterCreateParams<T>): Promise<T> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
-          const input = normalizeInput(metadata, toAuthRecord(data))
-          const entity = orm.em.create(metadata.class, input, { partial: true })
+          const input = normalizeInput(em, metadata, toAuthRecord(data))
+          const entity = em.create(metadata.class, input, { partial: true })
 
-          orm.em.persist(entity)
-          await orm.em.flush()
+          em.persist(entity)
+          await em.flush()
 
           return normalizeOutput(metadata, entity, normalizeSelect(model, select)) as T
         },
@@ -491,24 +508,23 @@ export function mikroOrmAdapter(
         },
 
         async delete({ model, where }: AdapterQueryParams): Promise<void> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
-          const entity = await orm.em.findOne(
-            metadata.class,
-            normalizeWhereClauses(metadata, where),
-          )
+          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
 
           if (!entity) {
             return
           }
 
-          orm.em.remove(entity)
-          await orm.em.flush()
+          em.remove(entity)
+          await em.flush()
         },
 
         async deleteMany({ model, where }: AdapterQueryParams): Promise<number> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
 
-          return orm.em.nativeDelete(metadata.class, normalizeWhereClauses(metadata, where))
+          return em.nativeDelete(metadata.class, normalizeWhereClauses(metadata, where))
         },
 
         async findMany<T>({
@@ -519,6 +535,7 @@ export function mikroOrmAdapter(
           sortBy,
           where,
         }: AdapterFindManyParams): Promise<T[]> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
           const options: PathRecord = {}
 
@@ -530,7 +547,7 @@ export function mikroOrmAdapter(
             setPath(options, ['orderBy', ...path], sortBy.direction)
           }
 
-          const rows = await orm.em.find(
+          const rows = await em.find(
             metadata.class,
             normalizeWhereClauses(metadata, where),
             options as AuthFindOptions,
@@ -541,11 +558,9 @@ export function mikroOrmAdapter(
         },
 
         async findOne<T>({ model, select, where }: AdapterFindOneParams): Promise<T | null> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
-          const entity = await orm.em.findOne(
-            metadata.class,
-            normalizeWhereClauses(metadata, where),
-          )
+          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
 
           if (!entity) {
             return null
@@ -555,29 +570,28 @@ export function mikroOrmAdapter(
         },
 
         async update<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<T | null> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
-          const entity = await orm.em.findOne(
-            metadata.class,
-            normalizeWhereClauses(metadata, where),
-          )
+          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
 
           if (!entity) {
             return null
           }
 
-          orm.em.assign(entity, normalizeInput(metadata, toAuthRecord(update)))
-          await orm.em.flush()
+          em.assign(entity, normalizeInput(em, metadata, toAuthRecord(update)))
+          await em.flush()
 
           return normalizeOutput(metadata, entity) as T
         },
 
         async updateMany<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<number> {
+          const em = resolveEntityManager(orm)
           const metadata = getEntityMetadata(model)
 
-          return orm.em.nativeUpdate(
+          return em.nativeUpdate(
             metadata.class,
             normalizeWhereClauses(metadata, where),
-            normalizeInput(metadata, toAuthRecord(update)),
+            normalizeInput(em, metadata, toAuthRecord(update)),
           )
         },
       }

--- a/apps/api/src/modules/auth/auth-db.adapter.ts
+++ b/apps/api/src/modules/auth/auth-db.adapter.ts
@@ -1,6 +1,5 @@
 import type {
   EntityData,
-  EntityManager,
   EntityMetadata,
   EntityName,
   EntityProperty,
@@ -12,7 +11,8 @@ import type { BetterAuthOptions } from 'better-auth'
 import type { CleanedWhere, DBAdapterDebugLogOption } from 'better-auth/adapters'
 import type { DBFieldAttribute } from 'better-auth/db'
 import { writeFileSync } from 'node:fs'
-import { ReferenceKind, RequestContext, serialize } from '@mikro-orm/core'
+import { ReferenceKind, serialize } from '@mikro-orm/core'
+import { EnsureRequestContext } from '@mikro-orm/decorators/legacy'
 import { BetterAuthError } from 'better-auth'
 import { createAdapterFactory } from 'better-auth/adapters'
 import { getAuthTables } from 'better-auth/db'
@@ -110,16 +110,6 @@ function throwAdapterError(message: string): never {
   throw new BetterAuthError(`[MikroORM Adapter] ${message}`)
 }
 
-// Better Auth is not only called from HTTP handlers. A WebSocket gateway, a
-// scheduled task or a queue worker has no ambient MikroORM context, and
-// `orm.em` refuses context-specific work when it is the global instance. Take
-// the contextual entity manager when there is one, a dedicated fork otherwise.
-// One call per adapter operation, so persist and flush stay on the same
-// instance.
-function resolveEntityManager(orm: MikroORM): EntityManager {
-  return RequestContext.getEntityManager() ?? orm.em.fork()
-}
-
 const OWN_REFERENCES: ReadonlySet<ReferenceKind> = new Set([
   ReferenceKind.SCALAR,
   ReferenceKind.ONE_TO_MANY,
@@ -133,11 +123,7 @@ interface AdapterUtils {
     fieldName: string,
     throwOnShadowProps?: boolean,
   ) => string[]
-  normalizeInput: (
-    em: EntityManager,
-    metadata: AuthEntityMetadata,
-    input: AuthRecord,
-  ) => AuthEntityData
+  normalizeInput: (metadata: AuthEntityMetadata, input: AuthRecord) => AuthEntityData
   normalizeOutput: (
     metadata: AuthEntityMetadata,
     output: AuthModelEntity,
@@ -250,14 +236,14 @@ export function createAdapterUtils(
     )
   }
 
-  const normalizeInput: AdapterUtils['normalizeInput'] = (em, metadata, input) => {
+  const normalizeInput: AdapterUtils['normalizeInput'] = (metadata, input) => {
     const fields: PathRecord = {}
 
     for (const [key, value] of Object.entries(input)) {
       const prop = getPropertyMetadata(metadata, key)
       const normalizedValue =
         prop.targetMeta && !OWN_REFERENCES.has(prop.kind)
-          ? em.getReference(prop.targetMeta.class as EntityName<AuthModelEntity>, value)
+          ? orm.em.getReference(prop.targetMeta.class as EntityName<AuthModelEntity>, value)
           : value
 
       setPath(fields, [prop.name], normalizedValue)
@@ -438,164 +424,194 @@ export function validateAuthSchema(orm: MikroORM, options: BetterAuthOptions): s
   return diffAuthSchema(orm, options).flatMap((diff) => diff.problems)
 }
 
+// Better Auth is not only called from HTTP handlers. A WebSocket gateway, a
+// scheduled task or a queue worker has no ambient MikroORM context, so
+// `orm.em` stays the global instance and MikroORM refuses context-specific
+// work. Every operation that touches the database is wrapped in
+// `@EnsureRequestContext`, which reuses the request fork when there is one,
+// joins the surrounding transaction when there is one, and opens a context for
+// the operation otherwise. `orm.em` then resolves to the same fork for the
+// whole method, so persist and flush stay on the same instance. The methods
+// live on a class because the decorator only applies to class members.
+class MikroOrmAuthAdapter {
+  private readonly utils: AdapterUtils
+
+  constructor(
+    private readonly orm: MikroORM,
+    config: Pick<AdapterFactoryCreatorConfig, 'getFieldName'>,
+  ) {
+    this.utils = createAdapterUtils(orm, config)
+  }
+
+  @EnsureRequestContext()
+  async count({ model, where }: AdapterQueryParams): Promise<number> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+
+    return em.count(metadata.class, this.utils.normalizeWhereClauses(metadata, where))
+  }
+
+  @EnsureRequestContext()
+  async create<T>({ data, model, select }: AdapterCreateParams<T>): Promise<T> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+    const input = this.utils.normalizeInput(metadata, toAuthRecord(data))
+    const entity = em.create(metadata.class, input, { partial: true })
+
+    em.persist(entity)
+    await em.flush()
+
+    const normalizedSelect = this.utils.normalizeSelect(model, select)
+
+    return this.utils.normalizeOutput(metadata, entity, normalizedSelect) as T
+  }
+
+  async createSchema({
+    file,
+    tables,
+  }: {
+    file?: string
+    tables: ReturnType<typeof getAuthTables>
+  }) {
+    const defaultPath = file ?? 'src/modules/auth/auth.entity.ts'
+    const diffs = diffAuthTables(this.orm, tables)
+
+    if (diffs.length === 0) {
+      return { code: '', path: defaultPath }
+    }
+
+    const patchedFiles = applyEntityPatches(diffs, this.orm, defaultPath)
+
+    if (patchedFiles.size > 0) {
+      const entries = [...patchedFiles.entries()].toSorted(([left], [right]) =>
+        left.localeCompare(right),
+      )
+      const [schemaPath, schemaContent] = entries.at(-1)!
+
+      for (const [path, content] of entries.slice(0, -1)) {
+        writeFileSync(path, content)
+      }
+
+      return { code: schemaContent, path: schemaPath, overwrite: true }
+    }
+
+    throwAdapterError(
+      `Cannot determine which MikroORM entity file should receive Better Auth schema changes. Check createMikroOrmOptions() entities discovery.`,
+    )
+  }
+
+  @EnsureRequestContext()
+  async delete({ model, where }: AdapterQueryParams): Promise<void> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+    const entity = await em.findOne(
+      metadata.class,
+      this.utils.normalizeWhereClauses(metadata, where),
+    )
+
+    if (!entity) {
+      return
+    }
+
+    em.remove(entity)
+    await em.flush()
+  }
+
+  @EnsureRequestContext()
+  async deleteMany({ model, where }: AdapterQueryParams): Promise<number> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+
+    return em.nativeDelete(metadata.class, this.utils.normalizeWhereClauses(metadata, where))
+  }
+
+  @EnsureRequestContext()
+  async findMany<T>({
+    limit,
+    model,
+    offset,
+    select,
+    sortBy,
+    where,
+  }: AdapterFindManyParams): Promise<T[]> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+    const options: PathRecord = {}
+
+    if (limit !== undefined) options.limit = limit
+    if (offset !== undefined) options.offset = offset
+
+    if (sortBy) {
+      const path = this.utils.getFieldPath(metadata, sortBy.field)
+      setPath(options, ['orderBy', ...path], sortBy.direction)
+    }
+
+    const rows = await em.find(
+      metadata.class,
+      this.utils.normalizeWhereClauses(metadata, where),
+      options as AuthFindOptions,
+    )
+    const normalizedSelect = this.utils.normalizeSelect(model, select)
+
+    return rows.map((row) => this.utils.normalizeOutput(metadata, row, normalizedSelect)) as T[]
+  }
+
+  @EnsureRequestContext()
+  async findOne<T>({ model, select, where }: AdapterFindOneParams): Promise<T | null> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+    const entity = await em.findOne(
+      metadata.class,
+      this.utils.normalizeWhereClauses(metadata, where),
+    )
+
+    if (!entity) {
+      return null
+    }
+
+    const normalizedSelect = this.utils.normalizeSelect(model, select)
+
+    return this.utils.normalizeOutput(metadata, entity, normalizedSelect) as T
+  }
+
+  @EnsureRequestContext()
+  async update<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<T | null> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+    const entity = await em.findOne(
+      metadata.class,
+      this.utils.normalizeWhereClauses(metadata, where),
+    )
+
+    if (!entity) {
+      return null
+    }
+
+    em.assign(entity, this.utils.normalizeInput(metadata, toAuthRecord(update)))
+    await em.flush()
+
+    return this.utils.normalizeOutput(metadata, entity) as T
+  }
+
+  @EnsureRequestContext()
+  async updateMany<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<number> {
+    const { em } = this.orm
+    const metadata = this.utils.getEntityMetadata(model)
+
+    return em.nativeUpdate(
+      metadata.class,
+      this.utils.normalizeWhereClauses(metadata, where),
+      this.utils.normalizeInput(metadata, toAuthRecord(update)),
+    )
+  }
+}
+
 export function mikroOrmAdapter(
   orm: MikroORM,
   { debugLogs, supportsJSON = true }: MikroOrmAdapterConfig = {},
 ) {
   return createAdapterFactory({
-    adapter(config) {
-      const {
-        getEntityMetadata,
-        getFieldPath,
-        normalizeInput,
-        normalizeOutput,
-        normalizeSelect,
-        normalizeWhereClauses,
-      } = createAdapterUtils(orm, config)
-
-      return {
-        async count({ model, where }: AdapterQueryParams): Promise<number> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-
-          return em.count(metadata.class, normalizeWhereClauses(metadata, where))
-        },
-
-        async create<T>({ data, model, select }: AdapterCreateParams<T>): Promise<T> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-          const input = normalizeInput(em, metadata, toAuthRecord(data))
-          const entity = em.create(metadata.class, input, { partial: true })
-
-          em.persist(entity)
-          await em.flush()
-
-          return normalizeOutput(metadata, entity, normalizeSelect(model, select)) as T
-        },
-
-        async createSchema({
-          file,
-          tables,
-        }: {
-          file?: string
-          tables: ReturnType<typeof getAuthTables>
-        }) {
-          const defaultPath = file ?? 'src/modules/auth/auth.entity.ts'
-          const diffs = diffAuthTables(orm, tables)
-
-          if (diffs.length === 0) {
-            return { code: '', path: defaultPath }
-          }
-
-          const patchedFiles = applyEntityPatches(diffs, orm, defaultPath)
-
-          if (patchedFiles.size > 0) {
-            const entries = [...patchedFiles.entries()].toSorted(([left], [right]) =>
-              left.localeCompare(right),
-            )
-            const [schemaPath, schemaContent] = entries.at(-1)!
-
-            for (const [path, content] of entries.slice(0, -1)) {
-              writeFileSync(path, content)
-            }
-
-            return { code: schemaContent, path: schemaPath, overwrite: true }
-          }
-
-          throwAdapterError(
-            `Cannot determine which MikroORM entity file should receive Better Auth schema changes. Check createMikroOrmOptions() entities discovery.`,
-          )
-        },
-
-        async delete({ model, where }: AdapterQueryParams): Promise<void> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
-
-          if (!entity) {
-            return
-          }
-
-          em.remove(entity)
-          await em.flush()
-        },
-
-        async deleteMany({ model, where }: AdapterQueryParams): Promise<number> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-
-          return em.nativeDelete(metadata.class, normalizeWhereClauses(metadata, where))
-        },
-
-        async findMany<T>({
-          limit,
-          model,
-          offset,
-          select,
-          sortBy,
-          where,
-        }: AdapterFindManyParams): Promise<T[]> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-          const options: PathRecord = {}
-
-          if (limit !== undefined) options.limit = limit
-          if (offset !== undefined) options.offset = offset
-
-          if (sortBy) {
-            const path = getFieldPath(metadata, sortBy.field)
-            setPath(options, ['orderBy', ...path], sortBy.direction)
-          }
-
-          const rows = await em.find(
-            metadata.class,
-            normalizeWhereClauses(metadata, where),
-            options as AuthFindOptions,
-          )
-          const normalizedSelect = normalizeSelect(model, select)
-
-          return rows.map((row) => normalizeOutput(metadata, row, normalizedSelect)) as T[]
-        },
-
-        async findOne<T>({ model, select, where }: AdapterFindOneParams): Promise<T | null> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
-
-          if (!entity) {
-            return null
-          }
-
-          return normalizeOutput(metadata, entity, normalizeSelect(model, select)) as T
-        },
-
-        async update<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<T | null> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-          const entity = await em.findOne(metadata.class, normalizeWhereClauses(metadata, where))
-
-          if (!entity) {
-            return null
-          }
-
-          em.assign(entity, normalizeInput(em, metadata, toAuthRecord(update)))
-          await em.flush()
-
-          return normalizeOutput(metadata, entity) as T
-        },
-
-        async updateMany<T>({ model, update, where }: AdapterUpdateParams<T>): Promise<number> {
-          const em = resolveEntityManager(orm)
-          const metadata = getEntityMetadata(model)
-
-          return em.nativeUpdate(
-            metadata.class,
-            normalizeWhereClauses(metadata, where),
-            normalizeInput(em, metadata, toAuthRecord(update)),
-          )
-        },
-      }
-    },
+    adapter: (config) => new MikroOrmAuthAdapter(orm, config),
     config: {
       adapterId: 'mikro-orm-adapter',
       adapterName: 'MikroORM Adapter',


### PR DESCRIPTION
The MikroORM adapter called `orm.em` directly in every operation. Inside an HTTP handler that resolves to the request-scoped fork through the Nest middleware, so it worked and nothing in this repository exercised the other case. Outside a request it stays the global instance, and MikroORM refuses context-specific work with `Using global EntityManager instance methods for context specific actions is disallowed`.

Better Auth is not only reached from HTTP handlers. A WebSocket gateway resolving a session from the upgrade request, a scheduled task, or a queue worker all land in the adapter with no ambient context, and every query throws. That is how it surfaced: a consumer project with a WebSocket gateway could not open a session at all once its auth persistence moved onto this adapter.

Raising `allowGlobalContext` was rejected. It silences the error by sharing one identity map across concurrent callers, which is the situation the option exists to prevent. Wrapping each non-HTTP entry point in a request context was rejected too: it puts the burden on every call site, and an adapter that only works under one kind of caller is the thing to fix.

Every operation that touches the database now carries `@EnsureRequestContext()`. It reuses the request fork when there is one, prefers the surrounding `TransactionContext` when the call happens inside `em.transactional`, and opens a context for the operation otherwise. Inside the method `orm.em` then resolves to that one fork for the whole body, so `persist` and `flush` stay on the same instance and `normalizeInput` keeps closing over `orm` rather than taking a manager parameter. `createSchema` stays undecorated: it only reads metadata and writes files.

The decorator only applies to class members, so the operations moved off the object literal returned by `adapter(config)` onto a `MikroOrmAuthAdapter` class holding the ORM and the utils. `createAdapterFactory` calls them as methods, so `this` is preserved and the factory changes to `adapter: (config) => new MikroOrmAuthAdapter(orm, config)`.

Verified against a real database with `allowGlobalContext` unset, driving `auth.$context.adapter` in three situations: no ambient context, inside a `RequestContext`, and inside `em.transactional`. Without the decorators the first case throws the global-context error; with them all three read, count, create, update and delete. The same check was run on two consumer projects carrying the identical adapter. Here, `pnpm --filter=api typecheck` passes and the API suite is green at 116 tests.

The migration intention is written around the decorator: its observable gaps cover the adapter shape, the decorated operations, and `normalizeInput` dropping its entity manager parameter.
