### PR TITLE
fix(auth): generate Better Auth string columns as PostgreSQL text

### DIFF
--- a/.boilerstone/migration-intentions/unreleased/auth-string-fields-as-text.md
+++ b/.boilerstone/migration-intentions/unreleased/auth-string-fields-as-text.md
@@ -1,0 +1,66 @@
+---
+id: unreleased/auth-string-fields-as-text
+domain: auth
+classification: migration
+---
+
+# Generate Better Auth string columns as PostgreSQL text
+
+## Goal
+
+`auth generate` emits `@Property({ type: 'text' })` for every Better Auth `type: "string"` field, and any already-generated JWKS `publicKey` / `privateKey` columns are unbounded `text` rather than `varchar(255)`.
+
+## Why
+
+Better Auth schema fields of `type: "string"` have no length. MikroORM's default string mapping is `varchar(255)`. Encrypted JWKS private keys, OAuth tokens, and passkey material already exceed 255 characters, so `GET /api/auth/get-session` after enabling the `jwt` plugin inserts into `jwks` and rolls back with `value too long for type character varying(255)`.
+
+Drizzle and Prisma adapters store these fields as unbounded text. A per-field heuristic (text only for JWKS, varchar for email) was rejected because Better Auth does not publish lengths, so the mapping would drift as plugins add tables. PostgreSQL stores `text` and unconstrained `varchar` the same way; `varchar(255)` only adds a truncation check.
+
+`auth generate` still only inserts missing models and fields. It does not rewrite an existing `@Property()`. New string fields become `text`; already-generated User / Session / Account / Verification columns stay `varchar(255)` until patched by hand. This intention therefore patches codegen for the future, and JWKS if that table already exists. It does not mass-convert the other auth tables.
+
+## Applies When
+
+- The project has `apps/api/src/modules/auth/auth-schema-codegen.ts`.
+- The API uses the in-tree Better Auth MikroORM adapter (`pnpm -F api auth:generate`).
+
+## Do Not Apply When
+
+- The project has no `api` app.
+- Auth does not go through this MikroORM adapter (a different ORM, or Better Auth's Kysely adapter).
+- A human has reviewed this intention and decided to keep `varchar(255)` on generated auth strings — record as skipped with that reason.
+
+## Observable Gaps
+
+1. **Codegen string mapping** — signal: `apps/api/src/modules/auth/auth-schema-codegen.ts` has no `if (stringType === 'string') options.push("type: 'text'")` next to the existing `json` / `array` mappings.
+   Copy that branch from the staged reference. Keep project-specific mappings for other Better Auth types.
+   Done when: `rg "type: 'text'" apps/api/src/modules/auth/auth-schema-codegen.ts` matches the string-type branch and `pnpm -F api test src/modules/auth/auth-schema-codegen.spec.ts` passes.
+
+2. **Codegen unit tests** — signal: `apps/api/src/modules/auth/auth-schema-codegen.spec.ts` is missing, or `renderProperty` is not exported.
+   Align the spec and the `renderProperty` export with the staged reference.
+   Done when: the spec asserts required string → `type: 'text'`, optional string → `nullable: true`, and a `defaultValue` still keeps `type: 'text'`.
+
+3. **JWKS key columns** — signal: `apps/api/src/modules/auth/entities/jwks.entity.ts` exists and `publicKey` / `privateKey` use `@Property()` with no `type: 'text'`.
+   Add `type: 'text'` on those two properties only. Create a MikroORM migration if the table already exists in the database.
+   Done when: both properties are `@Property({ type: 'text' })`. Skip this gap if the file does not exist (jwt plugin never generated).
+
+## Out of Scope
+
+- Mass-converting User, Session, Account, Passkey, or Verification string columns to `text`.
+- Enabling the Better Auth `jwt` plugin.
+- Changing JSON or array mappings in the codegen.
+
+## Reference Paths
+
+- `apps/api/src/modules/auth/auth-schema-codegen.ts` — **adapt**
+- `apps/api/src/modules/auth/auth-schema-codegen.spec.ts` — **adapt**
+- `apps/api/src/modules/auth/entities/jwks.entity.ts` — **adapt** (only if the consumer already generated it)
+
+## Validation
+
+- `pnpm -F api test src/modules/auth/auth-schema-codegen.spec.ts src/modules/auth/auth-db.adapter.spec.ts` passes.
+- `pnpm lint` passes.
+- If JWKS was patched, `pnpm --filter=api db:migrate:create` produces a migration that alters `publicKey` and `privateKey` to `text`.
+
+## Record Result
+
+Run `pnpm boilerplate upgrade record --id unreleased/auth-string-fields-as-text --applied` after validation passes, or record it as skipped with a reason. The id stays `unreleased/…` until the boilerplate release promotes it.

--- a/apps/api/src/modules/auth/auth-schema-codegen.spec.ts
+++ b/apps/api/src/modules/auth/auth-schema-codegen.spec.ts
@@ -1,0 +1,41 @@
+import type { AuthSchemaField } from './auth-db.adapter'
+import { describe, expect, it } from 'vitest'
+import { renderProperty } from './auth-schema-codegen'
+
+const unusedResolveEntity = () => undefined
+
+describe('renderProperty', () => {
+  it('maps a required Better Auth string field to PostgreSQL text', () => {
+    const inputField: AuthSchemaField = {
+      field: 'privateKey',
+      attribute: { type: 'string', required: true },
+    }
+
+    const actualProperty = renderProperty(inputField, unusedResolveEntity)
+
+    expect(actualProperty.code).toContain("@Property({ type: 'text' })")
+    expect(actualProperty.code).toContain('privateKey!: string')
+  })
+
+  it('maps an optional Better Auth string field to nullable text', () => {
+    const inputField: AuthSchemaField = {
+      field: 'image',
+      attribute: { type: 'string', required: false },
+    }
+
+    const actualProperty = renderProperty(inputField, unusedResolveEntity)
+
+    expect(actualProperty.code).toContain("@Property({ type: 'text', nullable: true })")
+  })
+
+  it('keeps type text when a string field has a default value', () => {
+    const inputField: AuthSchemaField = {
+      field: 'role',
+      attribute: { type: 'string', required: true, defaultValue: 'member' },
+    }
+
+    const actualProperty = renderProperty(inputField, unusedResolveEntity)
+
+    expect(actualProperty.code).toContain("type: 'text'")
+  })
+})

--- a/apps/api/src/modules/auth/auth-schema-codegen.ts
+++ b/apps/api/src/modules/auth/auth-schema-codegen.ts
@@ -77,7 +77,7 @@ export function createEntityResolver(
   }
 }
 
-interface RenderedProperty {
+export interface RenderedProperty {
   code: string
   decorators: Set<string>
   entityImports: Map<string, string>
@@ -101,7 +101,10 @@ function renderLiteral(value: AuthSchemaField['attribute']['defaultValue']): str
   return undefined
 }
 
-function renderProperty(field: AuthSchemaField, resolveEntity: EntityResolver): RenderedProperty {
+export function renderProperty(
+  field: AuthSchemaField,
+  resolveEntity: EntityResolver,
+): RenderedProperty {
   const { attribute } = field
   const decorators = new Set<string>(['Property'])
   const entityImports = new Map<string, string>()
@@ -144,6 +147,9 @@ function renderProperty(field: AuthSchemaField, resolveEntity: EntityResolver): 
   // EntityCaseNamingStrategy, so no explicit `fieldName` is needed.
   if (stringType === 'json') options.push("type: 'json'")
   if (stringType === 'string[]' || stringType === 'number[]') options.push("type: 'array'")
+  // Better Auth string fields have no length. MikroORM's default string is
+  // varchar(255), which truncates JWKS keys, tokens, and passkey material.
+  if (stringType === 'string') options.push("type: 'text'")
 
   if (stringType === 'date' && (field.field === 'createdAt' || field.field === 'updatedAt')) {
     typeImports.add('Opt')


### PR DESCRIPTION
Better Auth string fields have no length. MikroORM's default mapping is varchar(255), which truncates JWKS material, OAuth tokens, and passkey data after plugins such as jwt insert into those columns. Other official adapters already use unbounded text, and PostgreSQL stores text the same way as unconstrained varchar, so a per-field length heuristic was rejected.

auth generate still only inserts missing models and fields. It does not rewrite an existing @Property(), so already-generated User, Session, Account, and Verification columns stay varchar(255) until patched by hand. This change maps every new Better Auth string field to text and leaves those existing tables alone. Consumers that already generated a jwks entity should patch publicKey and privateKey only.