### PR TITLE
fix(monitoring): disable Sentry traces unless TRACES_SAMPLE_RATE is set

### DIFF
--- a/.boilerstone/migration-intentions/unreleased/sentry-traces-sample-rate.md
+++ b/.boilerstone/migration-intentions/unreleased/sentry-traces-sample-rate.md
@@ -1,0 +1,74 @@
+---
+id: unreleased/sentry-traces-sample-rate
+domain: monitoring
+classification: migration
+pr: 156
+---
+
+# Disable Sentry traces unless TRACES_SAMPLE_RATE is set
+
+## Goal
+
+Sentry `tracesSampleRate` comes from `TRACES_SAMPLE_RATE` (0–1). The default is `0`, so errors and logs still flow while traces stay off until a project opts in.
+
+## Why
+
+A DSN used to turn traces on at 100% in development and 10% in production. That is expensive for a boilerplate default. A numeric env var is the opt-in, not a second boolean: `0` disables traces, `0.1` is a typical production rate, `1.0` sends everything.
+
+## Applies When
+
+- The project has `apps/api/src/instrument.ts` (or equivalent) that calls `Sentry.init` with a `tracesSampleRate`.
+- `tracesSampleRate` is still hardcoded (for example `config.env === 'production' ? 0.1 : 1.0`), or `TRACES_SAMPLE_RATE` is missing from the API env schema. Still having the hardcoded rate is the starting state this intention migrates away from, not a skip reason.
+
+## Do Not Apply When
+
+- The project has no API app, or no Sentry bootstrap file.
+- The project does not use Sentry — record as skipped, and do not add Sentry.
+- The project uses a custom OpenTelemetry / Sentry bootstrap that is not this file — stop and ask rather than rewriting it.
+- A human has explicitly decided to keep a hardcoded sample rate after reviewing this intention — record as skipped with that reason.
+
+## Observable Gaps
+
+1. **Env schema** — signal: `apps/api/src/config/env.config.ts` has no `TRACES_SAMPLE_RATE`.
+   Add `TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0)` next to `SENTRY_DSN`, matching the staged reference. Do not rename or remove the DSN key.
+   Done when: the schema parses `TRACES_SAMPLE_RATE` and missing/unset values become `0`.
+
+2. **Config object** — signal: `config.sentry` has no `tracesSampleRate`.
+   Expose `tracesSampleRate: configParsed.data.TRACES_SAMPLE_RATE` on `config.sentry`, matching the staged reference.
+   Done when: `config.sentry.tracesSampleRate` exists and is a number.
+
+3. **Sentry init** — signal: `apps/api/src/instrument.ts` still sets `tracesSampleRate` from `config.env` (or another hardcoded number) instead of `config.sentry.tracesSampleRate`.
+   Pass `tracesSampleRate: config.sentry.tracesSampleRate`. Leave the Sentry/Langfuse branching and processors unchanged.
+   Done when: grepping `instrument.ts` shows `config.sentry.tracesSampleRate` and no `production ? 0.1 : 1.0` (or equivalent) sample-rate ternary.
+
+4. **Example env** — signal: `apps/api/.env.example` has no `TRACES_SAMPLE_RATE=0`.
+   Add that line under the Sentry block, matching the staged reference. Do not invent a DSN.
+   Done when: `.env.example` contains `TRACES_SAMPLE_RATE=0`.
+
+5. **Monitoring docs** — signal: `apps/documentation/src/content/docs/core-features/2_monitoring.mdx` (or the project's equivalent) still tells people that traces are captured automatically, or still shows a hardcoded `tracesSampleRate: 1.0`.
+   Adapt the staged reference: traces stay off at `0`; set `TRACES_SAMPLE_RATE` above `0` to opt in. Do not rewrite the rest of the monitoring page.
+   Done when: the page documents `TRACES_SAMPLE_RATE` and states that `0` is the default.
+
+## Out of Scope
+
+- Sentry DSN handling, Pino logs, and error reporting.
+- Langfuse processors, `skipOpenTelemetrySetup`, and the shared TracerProvider branching — those remain `unreleased/filter-langfuse-spans` / `v1.0.0/adopt-ai-module-baseline`.
+- `OpenTelemetryModule` registration and `@Traceable()` usage.
+- Frontend Sentry config in web-spa / web-ssr.
+
+## Reference Paths
+
+- `apps/api/src/config/env.config.ts` — **adapt**
+- `apps/api/src/instrument.ts` — **adapt**
+- `apps/api/.env.example` — **adapt**
+- `apps/documentation/src/content/docs/core-features/2_monitoring.mdx` — **adapt**
+
+## Validation
+
+- `pnpm --filter=api typecheck` passes.
+- The API boots with a Sentry DSN and without `TRACES_SAMPLE_RATE` set (traces stay off).
+- `instrument.ts` reads `config.sentry.tracesSampleRate`.
+
+## Record Result
+
+Run `pnpm boilerplate upgrade record --id unreleased/sentry-traces-sample-rate --applied` after validation passes, or record it as skipped with a reason. The id stays `unreleased/…` until the boilerplate release promotes it.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,6 +33,7 @@ LANGFUSE_BASE_URL=
 
 # Sentry
 SENTRY_DSN=
+TRACES_SAMPLE_RATE=0
 
 # Optional feature flags. isFeatureEnabled('example') reads FEATURE_EXAMPLE.
 # FEATURE_EXAMPLE=true

--- a/apps/api/src/config/env.config.ts
+++ b/apps/api/src/config/env.config.ts
@@ -73,6 +73,7 @@ export const configValidationSchema = z.object({
 
   // Sentry
   SENTRY_DSN: z.string().optional(),
+  TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
 })
 
 export type ConfigSchema = z.infer<typeof configValidationSchema>
@@ -143,5 +144,6 @@ export const config = {
   },
   sentry: {
     dsn: configParsed.data.SENTRY_DSN,
+    tracesSampleRate: configParsed.data.TRACES_SAMPLE_RATE,
   },
 } as const

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -31,7 +31,8 @@ const sentryConfig: Sentry.NodeOptions = {
   // Setting this option to true will send default PII data to Sentry.
   // For example, automatic IP address collection on events
   sendDefaultPii: true,
-  tracesSampleRate: config.env === 'production' ? 0.1 : 1.0,
+  // 0 disables traces (default). 1.0 sends everything. 0.1 is a typical production rate.
+  tracesSampleRate: config.sentry.tracesSampleRate,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/apps/documentation/src/content/docs/core-features/2_monitoring.mdx
+++ b/apps/documentation/src/content/docs/core-features/2_monitoring.mdx
@@ -55,9 +55,8 @@ Sentry.init({
   environment: config.env,
   release: config.version,
 
-  // Capture 100% of traces - reduce in production!
-  // Setting this above 0 automatically enables OpenTelemetry tracing.
-  tracesSampleRate: 1.0,
+  // 0 disables traces (the default). Set TRACES_SAMPLE_RATE to opt in.
+  tracesSampleRate: config.sentry.tracesSampleRate,
 
   // Send default PII data (e.g., IP addresses)
   sendDefaultPii: true,
@@ -71,13 +70,14 @@ Sentry.init({
 })
 ```
 
-<Aside type="caution" title="Performance in Production">
-The `tracesSampleRate: 1.0` setting captures 100% of traces, which is useful during development but can be expensive in production with high traffic.
+<Aside type="caution" title="Traces are off by default">
+Sentry error reporting and logs still work with only `SENTRY_DSN`. Distributed traces stay off while `TRACES_SAMPLE_RATE` is `0` (the default).
 
-**Recommended production settings:**
+Traces can be expensive on high-traffic production traffic. Typical values:
 
-- `tracesSampleRate: 0.1` (10% of traces) for high-traffic applications
-- `tracesSampleRate: 0.25` (25% of traces) for medium-traffic applications
+- `0` — no traces (default)
+- `1.0` — capture every trace (useful in development)
+- `0.1` — 10% of traces (a typical production rate)
 
 For error tracking, you can also use [dynamic sampling](https://docs.sentry.io/platforms/javascript/configuration/sampling/) for more granular control.
 
@@ -97,10 +97,12 @@ Since Sentry is already configured in the boilerplate, you only need to:
 
    ```env
    SENTRY_DSN=https://<your-dsn>@sentry.io/<your-project>
+   # Optional. Defaults to 0: errors and logs only, no traces.
+   TRACES_SAMPLE_RATE=0
    ```
 
 3. ### Start monitoring
-   That's it! Errors, traces, and logs are automatically captured.
+   That's it! Errors and logs are captured automatically. Set `TRACES_SAMPLE_RATE` above `0` if you also want distributed traces.
 
 </Steps>
 
@@ -115,7 +117,7 @@ Unhandled exceptions are automatically captured and sent to Sentry with:
 
 ## Viewing Traces
 
-Traces show the full request flow through your application:
+Traces stay off while `TRACES_SAMPLE_RATE` is `0`. They show the full request flow through your application:
 
 ![Sentry traces](../../../assets/sentry_traces.png)
 
@@ -214,6 +216,7 @@ Structured logs from Pino are automatically sent to Sentry:
 
    ```env
    SENTRY_DSN=
+   TRACES_SAMPLE_RATE=
    ```
 
 6. ### Update env.config.ts
@@ -223,10 +226,12 @@ Structured logs from Pino are automatically sent to Sentry:
    ```typescript
    // Remove from configValidationSchema:
    SENTRY_DSN: z.string().optional(),
+   TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
 
    // Remove from config object:
    sentry: {
      dsn: configParsed.data.SENTRY_DSN,
+     tracesSampleRate: configParsed.data.TRACES_SAMPLE_RATE,
    },
    ```
 


### PR DESCRIPTION
Sentry sampled every request in development and ten percent in production as soon as a DSN was present. That is a costly default for a boilerplate. The rate is now TRACES_SAMPLE_RATE, a number from 0 to 1, defaulting to 0 so errors and logs still flow while traces stay off until a project opts in.